### PR TITLE
Update Skiasharp version to 3.119.0 on Linux & Webasm to resolve crash issues on the corresponding platform.

### DIFF
--- a/UndertaleModToolAvalonia/UndertaleModToolAvalonia.csproj
+++ b/UndertaleModToolAvalonia/UndertaleModToolAvalonia.csproj
@@ -28,6 +28,8 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="SkiaSharp" Version="3.119.0" />
+        <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" />
+        <PackageReference Include="SkiaSharp.NativeAssets.WebAssembly" Version="3.119.0" />
         <PackageReference Include="Xaml.Behaviors" Version="11.3.2" />
     </ItemGroup>
 


### PR DESCRIPTION
## Description
Update Skiasharp version to 3.119.0 on Linux & Webasm to resolve crash issues on the corresponding platform.