### PR TITLE
Add audio playback through OpenAL

### DIFF
--- a/UndertaleModToolAvalonia/Helpers/AudioPlayback.cs
+++ b/UndertaleModToolAvalonia/Helpers/AudioPlayback.cs
@@ -1,0 +1,179 @@
+//#define USE_AUDIO_GROUPS
+
+using Avalonia.Controls;
+using NAudio.Wave;
+using NLayer;
+using NVorbis;
+using OpenTK.Audio.OpenAL;
+using System;
+#if USE_AUDIO_GROUPS
+using System.Collections.Generic;
+#endif
+using System.IO;
+using System.Threading.Tasks;
+using UndertaleModLib;
+using UndertaleModLib.Models;
+using Path = System.IO.Path;
+
+namespace UndertaleModToolAvalonia;
+
+public static class AudioPlayback
+{
+#if USE_AUDIO_GROUPS
+    readonly static Dictionary<string, UndertaleData> AudioGroups = [];
+#endif
+    static Window _window = null!;
+    static MainViewModel _mvm = null!;
+    readonly static ALDevice Device = ALC.OpenDevice(null);
+    readonly static ALContext Context = ALC.CreateContext(Device, [0]);
+    static int _source;
+    static int _buffer;
+
+    public static void Initialize(Window window, MainViewModel mvm)
+    {
+        ALC.MakeContextCurrent(Context);
+        _source = AL.GenSource();
+        _buffer = AL.GenBuffer();
+        _window = window;
+        _mvm = mvm;
+    }
+
+    public static void ClearResources()
+    {
+        StopResource();
+#if USE_AUDIO_GROUPS
+        foreach (var ag in AudioGroups.Values)
+            ag.Dispose();
+        AudioGroups.Clear();
+#endif
+    }
+
+    public static async Task PlayResource(UndertaleResource resource)
+    {
+        StopResource();
+        Stream? target = null;
+        try
+        {
+            if (resource is UndertaleSound snd)
+            {
+                if (snd.AudioFile != null)
+                    target = new MemoryStream(snd.AudioFile.Data);
+                else if ((snd.Flags & UndertaleSound.AudioEntryFlags.IsEmbedded) == 0)
+                {
+                    var path = Path.Combine(Path.GetDirectoryName(_mvm.DataPath) ?? "", snd.File.Content.Contains('.') ? snd.File.Content : (snd.File.Content + ".ogg"));
+                    if (File.Exists(path))
+                        target = File.OpenRead(path);
+                    else
+                        throw new("Failed to find the audio file.");
+                }
+                else if (snd.AudioID != -1 && snd.GroupID != 0)
+                {
+                    if (_mvm.DataPath == null)
+                        throw new("Failed to find the game's data folder.");
+#if USE_AUDIO_GROUPS
+                    var path = Path.Combine(Path.GetDirectoryName(_mvm.DataPath) ?? "", snd.AudioGroup is { Path: not null } ? snd.AudioGroup.Path.Content : $"audiogroup{snd.GroupID}.dat");
+                    if (File.Exists(path))
+                    {
+                        if (!AudioGroups.TryGetValue(path, out var data))
+                        {
+                            await using var stream = File.OpenRead(path);
+                            data = await Task.Run(() => UndertaleIO.Read(stream, (warn, _) => throw new(warn)));
+                            AudioGroups.Add(path, data);
+                        }
+                        target = new MemoryStream(data.EmbeddedAudio[snd.AudioID].Data);
+                    }
+                    else
+                        throw new("Failed to find the audio group file.");
+#else
+                    throw new("Audio groups are unsupported as of this moment.");
+#endif
+                }
+            }
+            else if (resource is UndertaleEmbeddedAudio emb)
+                target = new MemoryStream(emb.Data);
+        }
+        catch (Exception ex)
+        {
+            if (target != null)
+            {
+                await target.DisposeAsync();
+                target = null;
+            }
+            await new MessageWindow($"Failed to play the audio.\n{ex.Message}", "Audio playback", true).ShowDialog(_window);
+        }
+        if (target != null)
+        {
+            try
+            {
+                var header = new byte[4];
+                target.ReadAtLeast(header, 4);
+                target.Position = 0;
+                if ("RIFF"u8.SequenceEqual(header))
+                {
+                    var wav = new WaveFileReader(target);
+                    var buf = new byte[wav.Length];
+                    var read = wav.Read(buf, 0, buf.Length);
+                    if (wav.WaveFormat.BitsPerSample == 16)
+                    {
+                        var shortBuf = new short[read / 2];
+                        Buffer.BlockCopy(buf, 0, shortBuf, 0, read);
+                        AL.BufferData(_buffer, wav.WaveFormat.Channels == 1 ? ALFormat.Mono16 : ALFormat.Stereo16, shortBuf, wav.WaveFormat.SampleRate);
+                    }
+                    else if (wav.WaveFormat.BitsPerSample != 8)
+                        throw new("unsupported wav file");
+                    else
+                    {
+                        AL.BufferData(_buffer, wav.WaveFormat.Channels == 1 ? ALFormat.Mono8 : ALFormat.Stereo8, buf[..read], wav.WaveFormat.SampleRate);
+                    }
+                    await wav.DisposeAsync();
+                    AL.SourceQueueBuffer(_source, _buffer);
+                    AL.SourcePlay(_source);
+                }
+                else
+                {
+                    float[] buf;
+                    int read;
+                    int channels;
+                    int freq;
+                    if ("OggS"u8.SequenceEqual(header))
+                    {
+                        var ogg = new VorbisReader(target);
+                        buf = new float[ogg.TotalSamples];
+                        read = ogg.ReadSamples(buf);
+                        channels = ogg.Channels;
+                        freq = ogg.SampleRate;
+                        ogg.Dispose();
+                    }
+                    else if ("ID3"u8.SequenceEqual(header.AsSpan()[..3]))
+                    {
+                        var mp3 = new MpegFile(target);
+                        buf = new float[mp3.Length];
+                        read = mp3.ReadSamples(buf, 0, buf.Length);
+                        channels = mp3.Channels;
+                        freq = mp3.SampleRate;
+                        mp3.Dispose();
+                    }
+                    else
+                        throw new();
+                    var shortBuf = new short[read];
+                    for (var i = 0; i < read; i++)
+                        shortBuf[i] = (short)Math.Clamp(buf[i] * (1 << 15), short.MinValue, short.MaxValue);
+                    AL.BufferData(_buffer, channels == 1 ? ALFormat.Mono16 : ALFormat.Stereo16, shortBuf[..read], freq);
+                    AL.SourceQueueBuffer(_source, _buffer);
+                    AL.SourcePlay(_source);
+                }
+            }
+            catch (Exception ex)
+            {
+                await new MessageWindow($"Failed to play the audio.\n{ex.Message}", "Audio playback", true).ShowDialog(_window);
+            }
+            await target.DisposeAsync();
+        }
+    }
+
+    public static void StopResource()
+    {
+        AL.SourceStop(_source);
+        AL.SourceUnqueueBuffer(_source);
+    }
+}

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleEmbeddedAudioView.axaml
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleEmbeddedAudioView.axaml
@@ -18,7 +18,10 @@
                 <Button Command="{Binding ExportAudio}">Export audio</Button>
             </StackPanel>
 
-            <!-- TODO: Play audio -->
+            <StackPanel Orientation="Horizontal">
+                <Button Command="{Binding Play}">Play Audio</Button>
+                <Button Command="{Binding Stop}">Stop Audio</Button>
+            </StackPanel>
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleEmbeddedAudioViewModel.cs
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleEmbeddedAudioViewModel.cs
@@ -69,4 +69,14 @@ public partial class UndertaleEmbeddedAudioViewModel : IUndertaleResourceViewMod
         using Stream stream = await file.OpenWriteAsync();
         stream.Write(EmbeddedAudio.Data);
     }
+
+    public async void Play()
+    {
+        await AudioPlayback.PlayResource(Resource);
+    }
+
+    public void Stop()
+    {
+        AudioPlayback.StopResource();
+    }
 }

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleSoundView.axaml
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleSoundView.axaml
@@ -40,7 +40,12 @@
             <Label>Preload (old audio system)</Label>
             <CheckBox IsChecked="{Binding Sound.Preload}" />
 
-            <!-- TODO: Audio player -->
+            <!-- Empty label to align the buttons -->
+            <Label/>
+            <StackPanel Orientation="Horizontal" Spacing="5">
+                <Button Command="{Binding Play}">Play Audio</Button>
+                <Button Command="{Binding Stop}">Stop Audio</Button>
+            </StackPanel>
         </Grid>
     </ScrollViewer>
 </UserControl>

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleSoundViewModel.cs
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleSoundViewModel.cs
@@ -12,4 +12,14 @@ public partial class UndertaleSoundViewModel : IUndertaleResourceViewModel
     {
         Sound = sound;
     }
+
+    public async void Play()
+    {
+        await AudioPlayback.PlayResource(Resource);
+    }
+
+    public void Stop()
+    {
+        AudioPlayback.StopResource();
+    }
 }

--- a/UndertaleModToolAvalonia/UndertaleModToolAvalonia.csproj
+++ b/UndertaleModToolAvalonia/UndertaleModToolAvalonia.csproj
@@ -21,14 +21,21 @@
         <PackageReference Include="Avalonia.Skia" Version="11.3.11" />
         <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.11" />
 
-        <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.11" />
+        <!--Condition
+        below is needed to remove Avalonia.Diagnostics package from build output in Release
+        configuration.-->
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics"
+            Version="11.3.11" />
         <PackageReference Include="AvaloniaEdit.TextMate" Version="11.3.0" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.0.0" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" />
+        <PackageReference Include="NAudio.Core" Version="2.2.1" />
+        <PackageReference Include="NAudio.Vorbis" Version="1.5.0" />
+        <PackageReference Include="NLayer" Version="1.16.0" />
+        <PackageReference Include="OpenTK.OpenAL" Version="4.7.7" />
         <PackageReference Include="PropertyChanged.SourceGenerator" Version="1.1.2">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="SkiaSharp" Version="3.119.1" />
         <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.1" />

--- a/UndertaleModToolAvalonia/Windows/MainWindow.axaml.cs
+++ b/UndertaleModToolAvalonia/Windows/MainWindow.axaml.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia.Controls;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace UndertaleModToolAvalonia;
 
@@ -7,6 +8,13 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+    }
+
+    public override void Show()
+    {
+        base.Show();
+        if (!Design.IsDesignMode)
+            AudioPlayback.Initialize(this, App.Services.GetRequiredService<MainViewModel>());
     }
 
     protected override void OnClosing(WindowClosingEventArgs e)


### PR DESCRIPTION
## Description
Add the ability to play audio (both Sounds & Embedded audio)
<img width="1925" height="1017" alt="2025-08-19_21-41" src="https://github.com/user-attachments/assets/1dc641eb-af9d-4149-8990-2aba857110e9" />
Just like the original UndertaleModTool, this PR only introduces the Play/Stop buttons.

### Caveats
The audio playback is handled through a static data, which means the code is not thread safe, but it should not be triggered other than from the UI thread.
Audio groups get cached until the loaded data.win is changed, so it may eat up on resources on a game with too many audio groups.

### Notes
N/A