### PR TITLE
Small changes to bring it closer to UMT as it currently is

### DIFF
--- a/UndertaleModToolAvalonia/Controls/UndertaleResourceReferenceView.axaml
+++ b/UndertaleModToolAvalonia/Controls/UndertaleResourceReferenceView.axaml
@@ -12,8 +12,9 @@
                      Text="{Binding Reference, Mode=OneWay}"
                      ToolTip.Tip="{Binding Reference, Mode=OneWay}"
                      IsReadOnly="True"
-                     PointerReleased="TextBox_PointerReleased">
-                <TextBox.Resources>
+                     PointerReleased="TextBox_PointerReleased"
+                     DoubleTapped="TextBox_DoubleTapped">
+              <TextBox.Resources>
                     <l:UndertaleReferenceDropHandler x:Key="UndertaleReferenceDropHandler"/>
                 </TextBox.Resources>
                 <Interaction.Behaviors>

--- a/UndertaleModToolAvalonia/Controls/UndertaleResourceReferenceView.axaml.cs
+++ b/UndertaleModToolAvalonia/Controls/UndertaleResourceReferenceView.axaml.cs
@@ -70,6 +70,10 @@ public partial class UndertaleResourceReferenceView : UserControl
         }
     }
 
+    private void TextBox_DoubleTapped(object? sender, TappedEventArgs e) {
+        Open();
+    }
+
     public async void Add()
     {
         if (AddFunc is not null)


### PR DESCRIPTION
## Description
This PR makes it so that you can double click on asset references to go to them. 
It also makes the caret inside asset references transparent. I think this is ideal because you are not able to edit the text, so it doesn't "need" a caret, but if you want to select the text for copying, you can still do so by dragging. This is the current behavior in UMT.

Additionally, this PR makes it so that the program does not start maximized.

### Caveats
None

### Notes
None