### PR TITLE
feat(avalonia): improve resource editing and previews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ dlldata.c
 
 # Benchmark Results
 BenchmarkDotNet.Artifacts/
+perf-results/
 
 # .NET Core
 project.lock.json

--- a/UndertaleModLib/UndertaleModLib.csproj
+++ b/UndertaleModLib/UndertaleModLib.csproj
@@ -20,16 +20,17 @@
     <StartupObject />
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Fody" Version="6.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.13.0" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.14.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting.Common" Version="5.3.0" />
-    <PackageReference Include="PropertyChanged.Fody" Version="4.1.0" />
+    <PackageReference Include="PropertyChanged.Fody" Version="4.1.0" PrivateAssets="All" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
   </ItemGroup>
   <ItemGroup>
@@ -45,6 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Remove="gitversion.txt" />
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
     <Content Include="GameSpecificData\README.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  <ExcludeFromSingleFile>true</ExcludeFromSingleFile>

--- a/UndertaleModTool/UndertaleModTool.csproj
+++ b/UndertaleModTool/UndertaleModTool.csproj
@@ -88,7 +88,7 @@
             <Version>13.0.4</Version>
         </PackageReference>
         <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
-        <PackageReference Include="PropertyChanged.Fody" Version="4.1.0" />
+        <PackageReference Include="PropertyChanged.Fody" Version="4.1.0" PrivateAssets="All" />
         <PackageReference Include="Microsoft.Windows.Compatibility" Version="10.0.8" />
     </ItemGroup>
     <Target Name="AfterResolveReferences">

--- a/UndertaleModToolAvalonia.Tests/AudioMetadataTest.cs
+++ b/UndertaleModToolAvalonia.Tests/AudioMetadataTest.cs
@@ -1,0 +1,30 @@
+using UndertaleModToolAvalonia;
+
+namespace UndertaleModToolAvalonia.Tests;
+
+public class AudioMetadataTest
+{
+    [Fact]
+    public void DescribeFormat_RecognizesKnownHeaders()
+    {
+        Assert.Equal("WAV", AudioMetadata.DescribeFormat([0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x41, 0x56, 0x45]));
+        Assert.Equal("Ogg", AudioMetadata.DescribeFormat([0x4f, 0x67, 0x67, 0x53]));
+        Assert.Equal("FLAC", AudioMetadata.DescribeFormat([0x66, 0x4c, 0x61, 0x43]));
+        Assert.Equal("MP3", AudioMetadata.DescribeFormat([0x49, 0x44, 0x33]));
+        Assert.Equal("MP3", AudioMetadata.DescribeFormat([0xff, 0xfb]));
+        Assert.Equal("AIFF", AudioMetadata.DescribeFormat([0x46, 0x4f, 0x52, 0x4d, 0, 0, 0, 0, 0x41, 0x49, 0x46, 0x46]));
+    }
+
+    [Fact]
+    public void DescribeFormat_HandlesEmptyAndUnknownData()
+    {
+        Assert.Equal("Empty", AudioMetadata.DescribeFormat([]));
+        Assert.Equal("Unknown", AudioMetadata.DescribeFormat([1, 2, 3, 4]));
+    }
+
+    [Fact]
+    public void FormatByteCount_UsesInvariantSeparators()
+    {
+        Assert.Equal("1,024 bytes", AudioMetadata.FormatByteCount(1024));
+    }
+}

--- a/UndertaleModToolAvalonia.Tests/AudioPlayerTest.cs
+++ b/UndertaleModToolAvalonia.Tests/AudioPlayerTest.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace UndertaleModToolAvalonia.Tests;
+
+public class AudioPlayerTest
+{
+    [Fact]
+    public void Constructor_RejectsEmptyAudioBeforeInitializingBackend()
+    {
+        ArgumentException exception = Assert.Throws<ArgumentException>(() => new AudioPlayer([]));
+
+        Assert.Equal("data", exception.ParamName);
+    }
+}

--- a/UndertaleModToolAvalonia.Tests/ControlTest.cs
+++ b/UndertaleModToolAvalonia.Tests/ControlTest.cs
@@ -1,0 +1,86 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Headless.XUnit;
+using Avalonia.Interactivity;
+using UndertaleModLib.Models;
+
+namespace UndertaleModToolAvalonia.Tests;
+
+public class ControlTest
+{
+    [AvaloniaFact]
+    public void EditableDataGrid_AddThrowsActionableErrorWithoutItemFactory()
+    {
+        EditableDataGrid grid = new();
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(grid.Add);
+
+        Assert.Contains("ItemFactory", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Func<object>", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FlagEnumToStringConverter_ConvertBackWithoutViewReturnsDoNothing()
+    {
+        FlagEnumToStringConverter converter = new();
+
+        object? result = converter.ConvertBack("Regular", typeof(TestFlags), null, System.Globalization.CultureInfo.InvariantCulture);
+
+        Assert.Same(BindingOperations.DoNothing, result);
+    }
+
+    [AvaloniaFact]
+    public void FlagsBoxView_CheckChangedWithoutValueDoesNotThrow()
+    {
+        FlagsBoxView view = new();
+        CheckBox checkBox = new()
+        {
+            IsChecked = true,
+            DataContext = new FlagsBoxView.Flag(TestFlags.Regular, nameof(TestFlags.Regular), false),
+        };
+
+        view.Checked_IsCheckChanged(checkBox, new RoutedEventArgs());
+
+        Assert.Null(view.Value);
+    }
+
+    [AvaloniaFact]
+    public void ResourceReferenceView_OpenWithoutMainViewDoesNotThrow()
+    {
+        UndertaleResourceReferenceView view = new()
+        {
+            ReferenceType = typeof(UndertaleCode),
+        };
+
+        view.Open();
+        view.OpenInNewTab();
+    }
+
+    [AvaloniaFact]
+    public void StringReferenceView_OpenWithoutMainViewDoesNotThrow()
+    {
+        UndertaleStringReferenceView view = new();
+
+        view.Open();
+        view.OpenInNewTab();
+    }
+
+    [AvaloniaFact]
+    public void RoomEditor_NonRoomDataContextDoesNotThrow()
+    {
+        UndertaleRoomEditor editor = new()
+        {
+            DataContext = new object(),
+        };
+
+        editor.DataContext = null;
+    }
+
+    [Flags]
+    private enum TestFlags
+    {
+        None = 0,
+        Regular = 1,
+    }
+}

--- a/UndertaleModToolAvalonia.Tests/ConverterTest.cs
+++ b/UndertaleModToolAvalonia.Tests/ConverterTest.cs
@@ -1,0 +1,58 @@
+using System.Globalization;
+using Avalonia.Data;
+
+namespace UndertaleModToolAvalonia.Tests;
+
+public class ConverterTest
+{
+    [Fact]
+    public void OneWayConverters_ReturnDoNothingOnConvertBack()
+    {
+        object?[] results =
+        [
+            new EnumTypeToValuesConverter().ConvertBack(null, typeof(object), null, CultureInfo.InvariantCulture),
+            new EventsToExtendedEventConverter().ConvertBack(null, typeof(object), null, CultureInfo.InvariantCulture),
+            new LevelToWidthConverter().ConvertBack(null, typeof(object), null, CultureInfo.InvariantCulture),
+            new RoomItemToContextMenuConverter().ConvertBack(null, typeof(object), null, CultureInfo.InvariantCulture),
+            new TreeDataGridItemToContextMenuConverter().ConvertBack(null, typeof(object), null, CultureInfo.InvariantCulture),
+            new VersionCompareConverter().ConvertBack(null, typeof(object), null, CultureInfo.InvariantCulture),
+        ];
+
+        foreach (object? result in results)
+            Assert.Same(BindingOperations.DoNothing, result);
+    }
+
+    [Theory]
+    [InlineData("GE2", true)]
+    [InlineData("GE2.0.0.0", true)]
+    [InlineData("GE2.1", false)]
+    [InlineData("L2.1", true)]
+    [InlineData("L1.9", false)]
+    public void VersionCompareConverter_ComparesVersionTuples(string parameter, bool expected)
+    {
+        object? result = new VersionCompareConverter().Convert(
+            (2u, 0u, 1u, 0u),
+            typeof(bool),
+            parameter,
+            CultureInfo.InvariantCulture);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("GE")]
+    [InlineData("GE2.beta")]
+    [InlineData("GE2.0.0.0.1")]
+    public void VersionCompareConverter_ReturnsBindingErrorForInvalidParameters(string parameter)
+    {
+        object? result = new VersionCompareConverter().Convert(
+            (2u, 0u, 1u, 0u),
+            typeof(bool),
+            parameter,
+            CultureInfo.InvariantCulture);
+
+        BindingNotification notification = Assert.IsType<BindingNotification>(result);
+        Assert.Equal(BindingErrorType.Error, notification.ErrorType);
+    }
+}

--- a/UndertaleModToolAvalonia.Tests/EmbeddedAudioViewModelTest.cs
+++ b/UndertaleModToolAvalonia.Tests/EmbeddedAudioViewModelTest.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia.Input;
+using Avalonia.Platform.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using UndertaleModLib.Models;
+
+namespace UndertaleModToolAvalonia.Tests;
+
+public class EmbeddedAudioViewModelTest
+{
+    [Fact]
+    public async Task PlayAudioTask_ReturnsFalseWithoutAudioData()
+    {
+        UndertaleEmbeddedAudioViewModel vm = CreateViewModel(out _);
+
+        bool result = await vm.PlayAudioTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ImportAudioTask_ReturnsFalseWithoutView()
+    {
+        UndertaleEmbeddedAudioViewModel vm = CreateViewModel(out _);
+
+        bool result = await vm.ImportAudioTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ImportAudioTask_ReturnsFalseWhenPickerIsCanceled()
+    {
+        UndertaleEmbeddedAudioViewModel vm = CreateViewModel(out MainViewModel mainVM);
+        DialogView view = new();
+        mainVM.View = view;
+
+        bool result = await vm.ImportAudioTask();
+
+        Assert.False(result);
+        Assert.NotNull(view.LastOpenFileOptions);
+        Assert.Equal("Import audio", view.LastOpenFileOptions.Title);
+    }
+
+    [Fact]
+    public async Task ExportAudioTask_ReturnsFalseWithoutView()
+    {
+        UndertaleEmbeddedAudioViewModel vm = CreateViewModel(out _);
+
+        bool result = await vm.ExportAudioTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ExportAudioTask_ReturnsFalseWhenPickerIsCanceled()
+    {
+        UndertaleEmbeddedAudioViewModel vm = CreateViewModel(out MainViewModel mainVM);
+        DialogView view = new();
+        mainVM.View = view;
+
+        bool result = await vm.ExportAudioTask();
+
+        Assert.False(result);
+        Assert.NotNull(view.LastSaveFileOptions);
+        Assert.Equal("Export audio", view.LastSaveFileOptions.Title);
+    }
+
+    private static UndertaleEmbeddedAudioViewModel CreateViewModel(out MainViewModel mainVM)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<MainViewModel>();
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        mainVM = serviceProvider.GetRequiredService<MainViewModel>();
+        mainVM.Initialize();
+
+        UndertaleEmbeddedAudio audio = new()
+        {
+            Name = new UndertaleString("audio_test"),
+        };
+
+        return new UndertaleEmbeddedAudioViewModel(audio, serviceProvider);
+    }
+
+    private sealed class DialogView : IView
+    {
+        public FilePickerOpenOptions? LastOpenFileOptions { get; private set; }
+        public FilePickerSaveOptions? LastSaveFileOptions { get; private set; }
+
+        public Task<MessageWindow.Result> MessageDialog(
+            string message,
+            string? title = null,
+            MessageWindow.Buttons buttons = MessageWindow.Buttons.OK)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<IReadOnlyList<IStorageFile>> OpenFileDialog(FilePickerOpenOptions options)
+        {
+            LastOpenFileOptions = options;
+            return Task.FromResult<IReadOnlyList<IStorageFile>>([]);
+        }
+
+        public Task<IStorageFile?> SaveFileDialog(FilePickerSaveOptions options)
+        {
+            LastSaveFileOptions = options;
+            return Task.FromResult<IStorageFile?>(null);
+        }
+
+        public Task<IReadOnlyList<IStorageFolder>> OpenFolderDialog(FolderPickerOpenOptions options)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<bool> LaunchUriAsync(Uri uri)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<string?> TextBoxDialog(string message, string text = "", string? title = null, bool isMultiline = false, bool isReadOnly = false)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ILoaderWindow LoaderOpen()
+        {
+            throw new NotSupportedException();
+        }
+
+        public IInputElement? GetFocusedElement()
+        {
+            return null;
+        }
+    }
+}

--- a/UndertaleModToolAvalonia.Tests/EmbeddedTextureViewModelTest.cs
+++ b/UndertaleModToolAvalonia.Tests/EmbeddedTextureViewModelTest.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia.Input;
+using Avalonia.Platform.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using UndertaleModLib.Models;
+using UndertaleModLib.Util;
+
+namespace UndertaleModToolAvalonia.Tests;
+
+public class EmbeddedTextureViewModelTest
+{
+    [Fact]
+    public async Task ImportImageTask_ReturnsFalseWithoutView()
+    {
+        UndertaleEmbeddedTextureViewModel vm = CreateViewModel(out _);
+
+        bool result = await vm.ImportImageTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ImportImageTask_ReturnsFalseWhenPickerIsCanceled()
+    {
+        UndertaleEmbeddedTextureViewModel vm = CreateViewModel(out MainViewModel mainVM);
+        DialogView view = new();
+        mainVM.View = view;
+
+        bool result = await vm.ImportImageTask();
+
+        Assert.False(result);
+        Assert.NotNull(view.LastOpenFileOptions);
+        Assert.Equal("Import image", view.LastOpenFileOptions.Title);
+    }
+
+    [Fact]
+    public async Task ExportImageTask_ReturnsFalseWithoutView()
+    {
+        UndertaleEmbeddedTextureViewModel vm = CreateViewModel(out _);
+
+        bool result = await vm.ExportImageTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ExportImageTask_ReturnsFalseWhenPickerIsCanceled()
+    {
+        UndertaleEmbeddedTextureViewModel vm = CreateViewModel(out MainViewModel mainVM);
+        DialogView view = new();
+        mainVM.View = view;
+
+        bool result = await vm.ExportImageTask();
+
+        Assert.False(result);
+        Assert.NotNull(view.LastSaveFileOptions);
+        Assert.Equal("Export image", view.LastSaveFileOptions.Title);
+    }
+
+    [Fact]
+    public async Task ExportImageAsPNGTask_ReturnsFalseWithoutView()
+    {
+        UndertaleEmbeddedTextureViewModel vm = CreateViewModel(out _);
+
+        bool result = await vm.ExportImageAsPNGTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ExportImageAsPNGTask_ReturnsFalseWhenPickerIsCanceled()
+    {
+        UndertaleEmbeddedTextureViewModel vm = CreateViewModel(out MainViewModel mainVM);
+        DialogView view = new();
+        mainVM.View = view;
+
+        bool result = await vm.ExportImageAsPNGTask();
+
+        Assert.False(result);
+        Assert.NotNull(view.LastSaveFileOptions);
+        Assert.Equal("Export image as PNG", view.LastSaveFileOptions.Title);
+    }
+
+    private static UndertaleEmbeddedTextureViewModel CreateViewModel(out MainViewModel mainVM)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<MainViewModel>();
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        mainVM = serviceProvider.GetRequiredService<MainViewModel>();
+        mainVM.Initialize();
+
+        UndertaleEmbeddedTexture texture = new()
+        {
+            Name = new UndertaleString("Texture 0"),
+            TextureData = new UndertaleEmbeddedTexture.TexData
+            {
+                Image = new GMImage(1, 1),
+            },
+        };
+
+        return new UndertaleEmbeddedTextureViewModel(texture, serviceProvider);
+    }
+
+    private sealed class DialogView : IView
+    {
+        public FilePickerOpenOptions? LastOpenFileOptions { get; private set; }
+        public FilePickerSaveOptions? LastSaveFileOptions { get; private set; }
+
+        public Task<MessageWindow.Result> MessageDialog(
+            string message,
+            string? title = null,
+            MessageWindow.Buttons buttons = MessageWindow.Buttons.OK)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<IReadOnlyList<IStorageFile>> OpenFileDialog(FilePickerOpenOptions options)
+        {
+            LastOpenFileOptions = options;
+            return Task.FromResult<IReadOnlyList<IStorageFile>>([]);
+        }
+
+        public Task<IStorageFile?> SaveFileDialog(FilePickerSaveOptions options)
+        {
+            LastSaveFileOptions = options;
+            return Task.FromResult<IStorageFile?>(null);
+        }
+
+        public Task<IReadOnlyList<IStorageFolder>> OpenFolderDialog(FolderPickerOpenOptions options)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<bool> LaunchUriAsync(Uri uri)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<string?> TextBoxDialog(string message, string text = "", string? title = null, bool isMultiline = false, bool isReadOnly = false)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ILoaderWindow LoaderOpen()
+        {
+            throw new NotSupportedException();
+        }
+
+        public IInputElement? GetFocusedElement()
+        {
+            return null;
+        }
+    }
+}

--- a/UndertaleModToolAvalonia.Tests/HeadlessTest.cs
+++ b/UndertaleModToolAvalonia.Tests/HeadlessTest.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.IO;
+﻿using System.IO;
 using System.Threading.Tasks;
 using Avalonia.Headless.XUnit;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,17 +16,23 @@ public class HeadlessTest
         {
             DataContext = vm,
         };
-        mainWindow.Show();
 
-        await vm.NewData();
+        try
+        {
+            mainWindow.Show();
 
-        Assert.NotNull(vm.Data);
+            await vm.NewData();
 
-        using MemoryStream stream = new();
+            Assert.NotNull(vm.Data);
 
-        await vm.SaveData(stream);
-        Debug.WriteLine(stream.Length);
+            using MemoryStream stream = new();
 
-        Assert.Equal(2200, stream.Length);
+            await vm.SaveData(stream);
+            Assert.Equal(2200, stream.Length);
+        }
+        finally
+        {
+            mainWindow.Close();
+        }
     }
 }

--- a/UndertaleModToolAvalonia.Tests/ImportExportTest.cs
+++ b/UndertaleModToolAvalonia.Tests/ImportExportTest.cs
@@ -1,0 +1,87 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using ImageMagick;
+using UndertaleModLib.Models;
+using UndertaleModLib.Util;
+
+namespace UndertaleModToolAvalonia.Tests;
+
+public class ImportExportTest
+{
+    [Fact]
+    public async Task ImportEmbeddedAudio_ReadsNonSeekableStreams()
+    {
+        UndertaleEmbeddedAudio audio = new();
+        byte[] data = [1, 2, 3, 4];
+
+        using NonSeekableReadStream stream = new(data);
+
+        await ImportExport.ImportEmbeddedAudio(audio, stream);
+
+        Assert.Equal(data, audio.Data);
+    }
+
+    [Fact]
+    public async Task ExportEmbeddedAudio_WritesEmptyDataWhenAudioIsNull()
+    {
+        UndertaleEmbeddedAudio audio = new();
+        using MemoryStream stream = new();
+
+        await ImportExport.ExportEmbeddedAudio(audio, stream);
+
+        Assert.Empty(stream.ToArray());
+    }
+
+    [Fact]
+    public async Task ImportTexturePageItemAsPNG_ReplacesAtlasRegionAndUpdatesTargetSize()
+    {
+        UndertaleEmbeddedTexture texture = new()
+        {
+            TextureData = new UndertaleEmbeddedTexture.TexData
+            {
+                Image = new GMImage(4, 4),
+            },
+        };
+        UndertaleTexturePageItem item = new()
+        {
+            TexturePage = texture,
+            SourceX = 1,
+            SourceY = 1,
+            SourceWidth = 2,
+            SourceHeight = 2,
+            TargetWidth = 1,
+            TargetHeight = 1,
+            BoundingWidth = 2,
+            BoundingHeight = 2,
+        };
+        byte[] previousTextureData = texture.TextureData.Image.GetData();
+
+        using MagickImage replacement = new(MagickColors.Red, 2, 2);
+        replacement.Format = MagickFormat.Png32;
+        using MemoryStream stream = new();
+        replacement.Write(stream);
+        stream.Position = 0;
+
+        await ImportExport.ImportTexturePageItemAsPNG(item, stream);
+
+        Assert.Equal(2, item.TargetWidth);
+        Assert.Equal(2, item.TargetHeight);
+        Assert.NotEqual(previousTextureData, texture.TextureData.Image.GetData());
+    }
+
+    private sealed class NonSeekableReadStream(byte[] data) : MemoryStream(data)
+    {
+        public override bool CanSeek => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin loc) => throw new NotSupportedException();
+    }
+}

--- a/UndertaleModToolAvalonia.Tests/MainViewModelTest.cs
+++ b/UndertaleModToolAvalonia.Tests/MainViewModelTest.cs
@@ -1,0 +1,723 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia.Input;
+using Avalonia.Platform.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using UndertaleModLib;
+using UndertaleModLib.Project;
+using UndertaleModLib.Models;
+
+namespace UndertaleModToolAvalonia.Tests;
+
+public class MainViewModelTest
+{
+    [Fact]
+    public async Task FileNewTask_CreatesNewDataWhenNoSavePromptIsNeeded()
+    {
+        MainViewModel vm = CreateViewModel();
+
+        bool result = await vm.FileNewTask();
+
+        Assert.True(result);
+        Assert.NotNull(vm.Data);
+        Assert.Null(vm.DataPath);
+    }
+
+    [Fact]
+    public async Task FileCloseTask_ClearsDataWhenNoSavePromptIsNeeded()
+    {
+        MainViewModel vm = CreateViewModel();
+        vm.View = new DialogAnswerView(MessageWindow.Result.No);
+        await vm.NewData();
+
+        bool result = await vm.FileCloseTask();
+
+        Assert.True(result);
+        Assert.Null(vm.Data);
+        Assert.Null(vm.DataPath);
+    }
+
+    [Fact]
+    public async Task FileOpenTask_ReturnsFalseWithoutView()
+    {
+        MainViewModel vm = CreateViewModel();
+
+        bool result = await vm.FileOpenTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task FileOpenTask_ReturnsFalseWhenPickerIsCanceled()
+    {
+        MainViewModel vm = CreateViewModel();
+        DialogAnswerView view = new(MessageWindow.Result.No);
+        vm.View = view;
+
+        bool result = await vm.FileOpenTask();
+
+        Assert.False(result);
+        Assert.NotNull(view.LastOpenFileOptions);
+        Assert.Equal("Open data file", view.LastOpenFileOptions.Title);
+    }
+
+    [Fact]
+    public async Task FileSaveTask_ReturnsFalseWithoutView()
+    {
+        MainViewModel vm = CreateViewModel();
+        await vm.NewData();
+
+        bool result = await vm.FileSaveTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task FileSaveTask_ReturnsFalseWhenPickerIsCanceled()
+    {
+        MainViewModel vm = CreateViewModel();
+        DialogAnswerView view = new(MessageWindow.Result.No);
+        vm.View = view;
+        await vm.NewData();
+
+        bool result = await vm.FileSaveTask();
+
+        Assert.False(result);
+        Assert.NotNull(view.LastSaveFileOptions);
+        Assert.Equal("Save data file", view.LastSaveFileOptions.Title);
+    }
+
+    [Fact]
+    public async Task FileRunTask_ReturnsFalseWithoutData()
+    {
+        MainViewModel vm = CreateViewModel();
+
+        bool result = await vm.FileRunTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task FileRunTask_ReturnsFalseWithoutView()
+    {
+        MainViewModel vm = CreateViewModel();
+        await vm.NewData();
+
+        bool result = await vm.FileRunTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task FileRunTask_ReturnsFalseWhenRunnerPickerIsCanceled()
+    {
+        MainViewModel vm = CreateViewModel();
+        DialogAnswerView view = new(MessageWindow.Result.No);
+        vm.View = view;
+        await vm.NewData();
+
+        string dataPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.win");
+        try
+        {
+            File.WriteAllBytes(dataPath, []);
+            vm.DataPath = dataPath;
+
+            bool result = await vm.FileRunTask();
+
+            Assert.False(result);
+            Assert.NotNull(view.LastOpenFileOptions);
+            Assert.Equal("Open runner", view.LastOpenFileOptions.Title);
+        }
+        finally
+        {
+            File.Delete(dataPath);
+        }
+    }
+
+    [Fact]
+    public async Task OpenDroppedFilesTask_ReturnsFalseForNullFiles()
+    {
+        MainViewModel vm = CreateViewModel();
+
+        bool result = await vm.OpenDroppedFilesTask(null);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task OpenDroppedFilesTask_ReturnsFalseForEmptyFiles()
+    {
+        MainViewModel vm = CreateViewModel();
+
+        bool result = await vm.OpenDroppedFilesTask([]);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ScriptsRunOtherScriptTask_ReturnsFalseWithoutView()
+    {
+        MainViewModel vm = CreateViewModel();
+
+        bool result = await vm.ScriptsRunOtherScriptTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ScriptsRunOtherScriptTask_ReturnsFalseWhenPickerIsCanceled()
+    {
+        MainViewModel vm = CreateViewModel();
+        DialogAnswerView view = new(MessageWindow.Result.No);
+        vm.View = view;
+
+        bool result = await vm.ScriptsRunOtherScriptTask();
+
+        Assert.False(result);
+        Assert.NotNull(view.LastOpenFileOptions);
+        Assert.Equal("Run script", view.LastOpenFileOptions.Title);
+    }
+
+    [Fact]
+    public async Task RunScriptFileAsync_ReturnsFalseWithoutViewWhenFileIsMissing()
+    {
+        MainViewModel vm = CreateViewModel();
+        string path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.csx");
+
+        bool result = await vm.RunScriptFileAsync(path);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task RunScriptFileAsync_ShowsMessageWhenFileIsMissing()
+    {
+        MainViewModel vm = CreateViewModel();
+        DialogAnswerView view = new(MessageWindow.Result.OK);
+        vm.View = view;
+        string path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.csx");
+
+        bool result = await vm.RunScriptFileAsync(path);
+
+        Assert.False(result);
+        Assert.Equal("The script file doesn't exist.", view.LastMessage);
+    }
+
+    [Fact]
+    public async Task OnLoadedTask_ReturnsFalseWithoutView()
+    {
+        MainViewModel vm = CreateViewModel();
+        vm.LazyErrorMessages.Add("queued startup error");
+
+        bool result = await vm.OnLoadedTask();
+
+        Assert.False(result);
+        Assert.Single(vm.LazyErrorMessages);
+    }
+
+    [Fact]
+    public async Task OnLoadedTask_ShowsAndClearsLazyErrors()
+    {
+        MainViewModel vm = CreateViewModel();
+        DialogAnswerView view = new(MessageWindow.Result.OK);
+        vm.View = view;
+        vm.LazyErrorMessages.Add("first startup error");
+        vm.LazyErrorMessages.Add("second startup error");
+
+        bool result = await vm.OnLoadedTask();
+
+        Assert.True(result);
+        Assert.Empty(vm.LazyErrorMessages);
+        Assert.Equal(["first startup error", "second startup error"], view.Messages);
+    }
+
+    [Fact]
+    public async Task HelpGitHubTask_ReturnsFalseWithoutView()
+    {
+        MainViewModel vm = CreateViewModel();
+
+        bool result = await vm.HelpGitHubTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task HelpGitHubTask_LaunchesRepositoryUri()
+    {
+        MainViewModel vm = CreateViewModel();
+        DialogAnswerView view = new(MessageWindow.Result.OK);
+        vm.View = view;
+
+        bool result = await vm.HelpGitHubTask();
+
+        Assert.True(result);
+        Assert.Equal(new Uri("https://github.com/UnderminersTeam/UndertaleModTool"), view.LaunchedUri);
+    }
+
+    [Fact]
+    public async Task HelpAboutTask_ReturnsFalseWithoutView()
+    {
+        MainViewModel vm = CreateViewModel();
+
+        bool result = await vm.HelpAboutTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task HelpAboutTask_ShowsAboutDialog()
+    {
+        MainViewModel vm = CreateViewModel();
+        DialogAnswerView view = new(MessageWindow.Result.OK);
+        vm.View = view;
+
+        bool result = await vm.HelpAboutTask();
+
+        Assert.True(result);
+        Assert.Equal("About", view.LastMessageTitle);
+        Assert.StartsWith("UndertaleModTool v", view.LastMessage);
+        Assert.Contains("Licensed under the GNU General Public License Version 3.", view.LastMessage);
+    }
+
+    [Fact]
+    public async Task AskFileSave_ReturnsTrueWithoutData()
+    {
+        MainViewModel vm = CreateViewModel();
+
+        bool result = await vm.AskFileSave("save?");
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task AskFileSave_ReturnsFalseWithoutViewWhenDataIsLoaded()
+    {
+        MainViewModel vm = CreateViewModel();
+        await vm.NewData();
+
+        bool result = await vm.AskFileSave("save?");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task AskFileSave_ReturnsTrueWhenUserDeclinesSave()
+    {
+        MainViewModel vm = CreateViewModel();
+        vm.View = new DialogAnswerView(MessageWindow.Result.No);
+        await vm.NewData();
+
+        bool result = await vm.AskFileSave("save?");
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task AskFileSave_ReturnsFalseWhenUserCancels()
+    {
+        MainViewModel vm = CreateViewModel();
+        vm.View = new DialogAnswerView(MessageWindow.Result.Cancel);
+        await vm.NewData();
+
+        bool result = await vm.AskFileSave("save?");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task AskProjectSave_ReturnsTrueWithoutProject()
+    {
+        MainViewModel vm = CreateViewModel();
+
+        bool result = await vm.AskProjectSave("save project?");
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task AskProjectSave_ReturnsFalseWithoutViewWhenProjectHasUnexportedAssets()
+    {
+        MainViewModel vm = CreateViewModel();
+        await vm.NewData();
+        UndertalePath path = AddPath(vm, "path_dirty_project");
+        string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        ProjectContext project = ProjectContext.CreateWithDirectories(directory, directory, Path.Combine(directory, "project.json"));
+        project.MarkAssetForExport(path);
+        vm.Project = project;
+
+        bool result = await vm.AskProjectSave("save project?");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task LoadData_ReturnsFalseWithoutView()
+    {
+        MainViewModel vm = CreateViewModel();
+        using MemoryStream stream = new([]);
+
+        bool result = await vm.LoadData(stream);
+
+        Assert.False(result);
+        Assert.True(vm.IsEnabled);
+    }
+
+    [Fact]
+    public async Task SaveData_ReturnsFalseWithoutData()
+    {
+        MainViewModel vm = CreateViewModel();
+        vm.View = new DialogAnswerView(MessageWindow.Result.OK);
+        using MemoryStream stream = new();
+
+        bool result = await vm.SaveData(stream);
+
+        Assert.False(result);
+        Assert.True(vm.IsEnabled);
+    }
+
+    [Fact]
+    public async Task SaveData_ReturnsFalseWithoutView()
+    {
+        MainViewModel vm = CreateViewModel();
+        await vm.NewData();
+        using MemoryStream stream = new();
+
+        bool result = await vm.SaveData(stream);
+
+        Assert.False(result);
+        Assert.True(vm.IsEnabled);
+    }
+
+    [Fact]
+    public async Task ProjectCloseTask_ClearsProjectWhenNoSavePromptIsNeeded()
+    {
+        MainViewModel vm = CreateViewModel();
+        string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        ProjectContext project = ProjectContext.CreateWithDirectories(directory, directory, Path.Combine(directory, "project.json"));
+        vm.Project = project;
+
+        bool result = await vm.ProjectCloseTask();
+
+        Assert.True(result);
+        Assert.Null(vm.Project);
+    }
+
+    [Fact]
+    public async Task ProjectNewTask_ReturnsFalseWithoutData()
+    {
+        MainViewModel vm = CreateViewModel();
+        vm.View = new DialogAnswerView(MessageWindow.Result.OK);
+
+        bool result = await vm.ProjectNewTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ProjectNewTask_ReturnsFalseWithoutView()
+    {
+        MainViewModel vm = CreateViewModel();
+        await vm.NewData();
+        vm.DataPath = "source-data.win";
+
+        bool result = await vm.ProjectNewTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ProjectNewTask_ReturnsFalseWhenNamePromptIsCanceled()
+    {
+        MainViewModel vm = CreateViewModel();
+        DialogAnswerView view = new(MessageWindow.Result.OK);
+        vm.View = view;
+        await vm.NewData();
+        vm.DataPath = "source-data.win";
+
+        bool result = await vm.ProjectNewTask();
+
+        Assert.False(result);
+        Assert.Equal("Project name:", view.LastTextBoxMessage);
+    }
+
+    [Fact]
+    public async Task ProjectNewTask_KeepsCurrentProjectWhenFolderPickerIsCanceled()
+    {
+        MainViewModel vm = CreateViewModel();
+        DialogAnswerView view = new(MessageWindow.Result.OK)
+        {
+            TextBoxDialogResult = "Test Mod",
+        };
+        vm.View = view;
+        await vm.NewData();
+        vm.DataPath = "source-data.win";
+        ProjectContext project = ProjectContext.CreateWithDirectories(
+            Path.GetTempPath(),
+            Path.GetTempPath(),
+            Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.json"));
+        vm.Project = project;
+
+        bool result = await vm.ProjectNewTask();
+
+        Assert.False(result);
+        Assert.Same(project, vm.Project);
+        Assert.NotNull(view.LastOpenFolderOptions);
+        Assert.Equal("Select project folder", view.LastOpenFolderOptions.Title);
+    }
+
+    [Fact]
+    public async Task ProjectOpenTask_ReturnsFalseWithoutView()
+    {
+        MainViewModel vm = CreateViewModel();
+        await vm.NewData();
+        vm.DataPath = "source-data.win";
+
+        bool result = await vm.ProjectOpenTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ProjectOpenTask_ReturnsFalseWhenProjectPickerIsCanceled()
+    {
+        MainViewModel vm = CreateViewModel();
+        DialogAnswerView view = new(MessageWindow.Result.OK);
+        vm.View = view;
+        await vm.NewData();
+        vm.DataPath = "source-data.win";
+
+        bool result = await vm.ProjectOpenTask();
+
+        Assert.False(result);
+        Assert.NotNull(view.LastOpenFileOptions);
+        Assert.Equal("Select project.json file", view.LastOpenFileOptions.Title);
+    }
+
+    [Fact]
+    public async Task ProjectOpenTask_KeepsCurrentProjectWhenProjectPickerIsCanceled()
+    {
+        MainViewModel vm = CreateViewModel();
+        DialogAnswerView view = new(MessageWindow.Result.OK);
+        vm.View = view;
+        await vm.NewData();
+        vm.DataPath = "source-data.win";
+        ProjectContext project = ProjectContext.CreateWithDirectories(
+            Path.GetTempPath(),
+            Path.GetTempPath(),
+            Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.json"));
+        vm.Project = project;
+
+        bool result = await vm.ProjectOpenTask();
+
+        Assert.False(result);
+        Assert.Same(project, vm.Project);
+        Assert.NotNull(view.LastOpenFileOptions);
+        Assert.Equal("Select project.json file", view.LastOpenFileOptions.Title);
+    }
+
+    [Fact]
+    public async Task DataItemAddTask_ReturnsFalseWithoutViewWhenNamePromptIsNeeded()
+    {
+        MainViewModel vm = CreateViewModel();
+        await vm.NewData();
+        int initialCount = vm.Data!.Sprites.Count;
+
+        bool result = await vm.DataItemAddTask(vm.Data["Sprites"]);
+
+        Assert.False(result);
+        Assert.Equal(initialCount, vm.Data.Sprites.Count);
+    }
+
+    [Fact]
+    public async Task DataItemAddTask_ReturnsFalseWhenNamePromptIsCanceled()
+    {
+        MainViewModel vm = CreateViewModel();
+        vm.View = new DialogAnswerView(MessageWindow.Result.OK);
+        await vm.NewData();
+        int initialCount = vm.Data!.Sprites.Count;
+
+        bool result = await vm.DataItemAddTask(vm.Data["Sprites"]);
+
+        Assert.False(result);
+        Assert.Equal(initialCount, vm.Data.Sprites.Count);
+    }
+
+    [Fact]
+    public async Task DataItemAddTask_RejectsInvalidAssetName()
+    {
+        MainViewModel vm = CreateViewModel();
+        DialogAnswerView view = new(MessageWindow.Result.OK)
+        {
+            TextBoxDialogResult = "123 bad"
+        };
+        vm.View = view;
+        await vm.NewData();
+        int initialCount = vm.Data!.Sprites.Count;
+
+        bool result = await vm.DataItemAddTask(vm.Data["Sprites"]);
+
+        Assert.False(result);
+        Assert.Equal(initialCount, vm.Data.Sprites.Count);
+        Assert.Contains("is not a valid identifier", view.LastMessage);
+    }
+
+    [Fact]
+    public async Task DataItemAddTask_AddsNamedResource()
+    {
+        MainViewModel vm = CreateViewModel();
+        vm.View = new DialogAnswerView(MessageWindow.Result.OK)
+        {
+            TextBoxDialogResult = "spr_added"
+        };
+        await vm.NewData();
+
+        bool result = await vm.DataItemAddTask(vm.Data!["Sprites"]);
+
+        Assert.True(result);
+        Assert.Single(vm.Data.Sprites);
+        Assert.Equal("spr_added", vm.Data.Sprites[0].Name.Content);
+    }
+
+    [Fact]
+    public async Task DataItemRemoveTask_ReturnsFalseWithoutView()
+    {
+        MainViewModel vm = CreateViewModel();
+        await vm.NewData();
+        UndertaleSprite sprite = AddSprite(vm, "spr_remove");
+
+        bool result = await vm.DataItemRemoveTask(sprite);
+
+        Assert.False(result);
+        Assert.Contains(sprite, vm.Data!.Sprites);
+    }
+
+    [Fact]
+    public async Task DataItemRemoveTask_ReturnsFalseWhenDeleteIsCanceled()
+    {
+        MainViewModel vm = CreateViewModel();
+        vm.View = new DialogAnswerView(MessageWindow.Result.No);
+        await vm.NewData();
+        UndertaleSprite sprite = AddSprite(vm, "spr_remove");
+
+        bool result = await vm.DataItemRemoveTask(sprite);
+
+        Assert.False(result);
+        Assert.Contains(sprite, vm.Data!.Sprites);
+    }
+
+    [Fact]
+    public async Task DataItemRemoveTask_RemovesResourceWhenConfirmed()
+    {
+        MainViewModel vm = CreateViewModel();
+        vm.View = new DialogAnswerView(MessageWindow.Result.Yes);
+        await vm.NewData();
+        UndertaleSprite sprite = AddSprite(vm, "spr_remove");
+
+        bool result = await vm.DataItemRemoveTask(sprite);
+
+        Assert.True(result);
+        Assert.DoesNotContain(sprite, vm.Data!.Sprites);
+    }
+
+    private static MainViewModel CreateViewModel()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<MainViewModel>();
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        MainViewModel vm = serviceProvider.GetRequiredService<MainViewModel>();
+        vm.Initialize();
+        return vm;
+    }
+
+    private static UndertaleSprite AddSprite(MainViewModel vm, string name)
+    {
+        UndertaleSprite sprite = new()
+        {
+            Name = vm.Data!.Strings.MakeString(name, createNew: true)
+        };
+        vm.Data.Sprites.Add(sprite);
+        return sprite;
+    }
+
+    private static UndertalePath AddPath(MainViewModel vm, string name)
+    {
+        UndertalePath path = new()
+        {
+            Name = vm.Data!.Strings.MakeString(name, createNew: true)
+        };
+        vm.Data.Paths.Add(path);
+        return path;
+    }
+
+    private sealed class DialogAnswerView(MessageWindow.Result result) : IView
+    {
+        public Uri? LaunchedUri { get; private set; }
+        public string? LastMessage { get; private set; }
+        public string? LastMessageTitle { get; private set; }
+        public string? LastTextBoxMessage { get; private set; }
+        public string? LastTextBoxText { get; private set; }
+        public List<string> Messages { get; } = [];
+        public FilePickerOpenOptions? LastOpenFileOptions { get; private set; }
+        public FilePickerSaveOptions? LastSaveFileOptions { get; private set; }
+        public FolderPickerOpenOptions? LastOpenFolderOptions { get; private set; }
+        public IReadOnlyList<IStorageFile> OpenFileDialogResult { get; init; } = [];
+        public IStorageFile? SaveFileDialogResult { get; init; }
+        public IReadOnlyList<IStorageFolder> OpenFolderDialogResult { get; init; } = [];
+        public string? TextBoxDialogResult { get; init; }
+
+        public Task<MessageWindow.Result> MessageDialog(
+            string message,
+            string? title = null,
+            MessageWindow.Buttons buttons = MessageWindow.Buttons.OK)
+        {
+            LastMessage = message;
+            LastMessageTitle = title;
+            Messages.Add(message);
+            return Task.FromResult(result);
+        }
+
+        public Task<IReadOnlyList<IStorageFile>> OpenFileDialog(FilePickerOpenOptions options)
+        {
+            LastOpenFileOptions = options;
+            return Task.FromResult(OpenFileDialogResult);
+        }
+
+        public Task<IStorageFile?> SaveFileDialog(FilePickerSaveOptions options)
+        {
+            LastSaveFileOptions = options;
+            return Task.FromResult(SaveFileDialogResult);
+        }
+
+        public Task<IReadOnlyList<IStorageFolder>> OpenFolderDialog(FolderPickerOpenOptions options)
+        {
+            LastOpenFolderOptions = options;
+            return Task.FromResult(OpenFolderDialogResult);
+        }
+
+        public Task<bool> LaunchUriAsync(Uri uri)
+        {
+            LaunchedUri = uri;
+            return Task.FromResult(true);
+        }
+
+        public Task<string?> TextBoxDialog(string message, string text = "", string? title = null, bool isMultiline = false, bool isReadOnly = false)
+        {
+            LastTextBoxMessage = message;
+            LastTextBoxText = text;
+            return Task.FromResult(TextBoxDialogResult);
+        }
+
+        public ILoaderWindow LoaderOpen()
+        {
+            throw new NotSupportedException();
+        }
+
+        public IInputElement? GetFocusedElement()
+        {
+            return null;
+        }
+    }
+}

--- a/UndertaleModToolAvalonia.Tests/MainViewTest.cs
+++ b/UndertaleModToolAvalonia.Tests/MainViewTest.cs
@@ -1,0 +1,40 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace UndertaleModToolAvalonia.Tests;
+
+public class MainViewTest
+{
+    [AvaloniaFact]
+    public void TreeSelectionWithoutTreeSourceDoesNotThrow()
+    {
+        MainViewModel vm = CreateViewModel();
+        object value = new();
+        MainViewModel.TreeDataGridItem item = new()
+        {
+            Text = "item",
+            Value = value,
+        };
+        vm.TreeDataGridData.Add(item);
+
+        MainView view = new()
+        {
+            DataContext = vm,
+        };
+        TreeDataGrid treeDataGrid = view.FindControl<TreeDataGrid>("MainTreeDataGrid")!;
+        treeDataGrid.Source = null;
+
+        view.ExpandItemOnTree(item);
+        view.SelectValueInTree(value);
+    }
+
+    private static MainViewModel CreateViewModel()
+    {
+        ServiceProvider serviceProvider = new ServiceCollection()
+            .AddSingleton<MainViewModel>()
+            .BuildServiceProvider();
+
+        return serviceProvider.GetRequiredService<MainViewModel>();
+    }
+}

--- a/UndertaleModToolAvalonia.Tests/ObservableCollectionViewTest.cs
+++ b/UndertaleModToolAvalonia.Tests/ObservableCollectionViewTest.cs
@@ -4,6 +4,16 @@ namespace UndertaleModToolAvalonia.Tests;
 
 public class ObservableCollectionViewTest
 {
+    private sealed class ManualNotifyList<T> : System.Collections.Generic.List<T>, System.Collections.Specialized.INotifyCollectionChanged
+    {
+        public event System.Collections.Specialized.NotifyCollectionChangedEventHandler? CollectionChanged;
+
+        public void Raise(System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            CollectionChanged?.Invoke(this, e);
+        }
+    }
+
     [Fact]
     public void Test_ObservableCollectionView()
     {
@@ -128,5 +138,34 @@ public class ObservableCollectionViewTest
 
         view.SetFilter(x => true);
         Assert.Equal(output, ["A", "B", "C", "D", "E"]);
+    }
+
+    [Fact]
+    public void AddNotificationWithoutIndexFallsBackToReset()
+    {
+        ManualNotifyList<string> input = ["a"];
+        var view = new ObservableCollectionView<string, string>(input);
+
+        input.Add("b");
+        input.Raise(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+            System.Collections.Specialized.NotifyCollectionChangedAction.Add,
+            "b"));
+
+        Assert.Equal(["a", "b"], view.Output);
+    }
+
+    [Fact]
+    public void ReplaceNotificationWithoutIndexFallsBackToReset()
+    {
+        ManualNotifyList<string> input = ["a"];
+        var view = new ObservableCollectionView<string, string>(input);
+
+        input[0] = "b";
+        input.Raise(new System.Collections.Specialized.NotifyCollectionChangedEventArgs(
+            System.Collections.Specialized.NotifyCollectionChangedAction.Replace,
+            "b",
+            "a"));
+
+        Assert.Equal(["b"], view.Output);
     }
 }

--- a/UndertaleModToolAvalonia.Tests/RoomViewModelTest.cs
+++ b/UndertaleModToolAvalonia.Tests/RoomViewModelTest.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia.Input;
+using Avalonia.Platform.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using UndertaleModLib;
+using UndertaleModLib.Models;
+
+namespace UndertaleModToolAvalonia.Tests;
+
+public class RoomViewModelTest
+{
+    [Fact]
+    public async Task SaveAsImageTask_ReturnsFalseWithoutView()
+    {
+        UndertaleRoomViewModel vm = await CreateViewModel();
+
+        bool result = await vm.SaveAsImageTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task SaveAsImageTask_ReturnsFalseWhenPickerIsCanceled()
+    {
+        UndertaleRoomViewModel vm = await CreateViewModel();
+        DialogView view = new();
+        vm.MainVM.View = view;
+
+        bool result = await vm.SaveAsImageTask();
+
+        Assert.False(result);
+        Assert.NotNull(view.LastSaveFileOptions);
+        Assert.Equal("Save image", view.LastSaveFileOptions.Title);
+    }
+
+    private static async Task<UndertaleRoomViewModel> CreateViewModel()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<MainViewModel>();
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        MainViewModel mainVM = serviceProvider.GetRequiredService<MainViewModel>();
+        mainVM.Initialize();
+        mainVM.Settings = new SettingsFile(serviceProvider);
+        await mainVM.NewData();
+
+        UndertaleRoom room = new()
+        {
+            Name = mainVM.Data!.Strings.MakeString("room_test", createNew: true),
+        };
+        mainVM.Data.Rooms.Add(room);
+
+        return new UndertaleRoomViewModel(room, serviceProvider);
+    }
+
+    private sealed class DialogView : IView
+    {
+        public FilePickerSaveOptions? LastSaveFileOptions { get; private set; }
+
+        public Task<MessageWindow.Result> MessageDialog(
+            string message,
+            string? title = null,
+            MessageWindow.Buttons buttons = MessageWindow.Buttons.OK)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<IReadOnlyList<IStorageFile>> OpenFileDialog(FilePickerOpenOptions options)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<IStorageFile?> SaveFileDialog(FilePickerSaveOptions options)
+        {
+            LastSaveFileOptions = options;
+            return Task.FromResult<IStorageFile?>(null);
+        }
+
+        public Task<IReadOnlyList<IStorageFolder>> OpenFolderDialog(FolderPickerOpenOptions options)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<bool> LaunchUriAsync(Uri uri)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<string?> TextBoxDialog(string message, string text = "", string? title = null, bool isMultiline = false, bool isReadOnly = false)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ILoaderWindow LoaderOpen()
+        {
+            throw new NotSupportedException();
+        }
+
+        public IInputElement? GetFocusedElement()
+        {
+            return null;
+        }
+    }
+}

--- a/UndertaleModToolAvalonia.Tests/ScriptingTest.cs
+++ b/UndertaleModToolAvalonia.Tests/ScriptingTest.cs
@@ -1,0 +1,271 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Platform.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using UndertaleModLib.Scripting;
+
+namespace UndertaleModToolAvalonia.Tests;
+
+public class ScriptingTest
+{
+    [AvaloniaFact]
+    public async Task RunCommandTextAsync_ReturnsResultAndTracksSuccess()
+    {
+        MainViewModel vm = CreateViewModel();
+
+        vm.CommandTextBoxText = "1 + 2";
+        await vm.RunCommandTextAsync();
+
+        Assert.True(vm.Scripting.ScriptExecutionSuccess);
+        Assert.Equal("", vm.Scripting.ScriptErrorMessage);
+        Assert.Equal("", vm.Scripting.ScriptErrorType);
+        Assert.Equal("3", vm.CommandTextBoxText);
+    }
+
+    [AvaloniaFact]
+    public void RunUMTScript_RunsFileScriptAndTracksSuccess()
+    {
+        MainViewModel vm = CreateViewModel();
+        string scriptPath = Path.GetTempFileName();
+        File.WriteAllText(scriptPath, "SetUMTConsoleText(\"file script ran\");");
+
+        try
+        {
+            ScriptGlobals globals = new(vm.Scripting, null);
+
+            Assert.True(globals.RunUMTScript(scriptPath));
+            Assert.True(vm.Scripting.ScriptExecutionSuccess);
+            Assert.Equal("file script ran", vm.CommandTextBoxText);
+        }
+        finally
+        {
+            File.Delete(scriptPath);
+        }
+    }
+
+    [AvaloniaFact]
+    public void LintUMTScript_CompilesFileWithoutRunningIt()
+    {
+        MainViewModel vm = CreateViewModel();
+        string scriptPath = Path.GetTempFileName();
+        File.WriteAllText(scriptPath, "SetUMTConsoleText(\"should not run\");");
+
+        try
+        {
+            ScriptGlobals globals = new(vm.Scripting, null);
+
+            Assert.True(globals.LintUMTScript(scriptPath));
+            Assert.True(vm.Scripting.ScriptExecutionSuccess);
+            Assert.Equal("", vm.CommandTextBoxText);
+        }
+        finally
+        {
+            File.Delete(scriptPath);
+        }
+    }
+
+    [AvaloniaFact]
+    public void LintUMTScript_MissingFileReportsErrorWithoutView()
+    {
+        MainViewModel vm = CreateViewModel();
+        ScriptGlobals globals = new(vm.Scripting, null);
+        string scriptPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), "missing.csx");
+
+        Assert.False(globals.LintUMTScript(scriptPath));
+        Assert.False(vm.Scripting.ScriptExecutionSuccess);
+        Assert.Equal("FileNotFoundException", vm.Scripting.ScriptErrorType);
+        Assert.Contains(scriptPath, vm.CommandTextBoxText);
+    }
+
+    [AvaloniaFact]
+    public void MakeNewDataFile_CreatesDataWithoutBlockingOnTaskResult()
+    {
+        MainViewModel vm = CreateViewModel();
+        ScriptGlobals globals = new(vm.Scripting, null);
+
+        Assert.Null(vm.Data);
+        Assert.True(globals.MakeNewDataFile());
+        Assert.NotNull(vm.Data);
+        Assert.True(vm.Scripting.ScriptExecutionSuccess);
+    }
+
+    [AvaloniaFact]
+    public void LintUMTScript_CompilesStockExportAllSoundsScript()
+    {
+        MainViewModel vm = CreateViewModel();
+        ScriptGlobals globals = new(vm.Scripting, null);
+        string scriptPath = FindRepositoryFile(Path.Combine(
+            "UndertaleModTool",
+            "Scripts",
+            "Resource Exporters",
+            "ExportAllSounds.csx"));
+
+        Assert.True(globals.LintUMTScript(scriptPath), vm.Scripting.ScriptErrorMessage);
+        Assert.True(vm.Scripting.ScriptExecutionSuccess);
+    }
+
+    [AvaloniaFact]
+    public void LintScript_UsesDefaultUndertaleScriptReferences()
+    {
+        MainViewModel vm = CreateViewModel();
+        string script = """
+            using ImageMagick;
+            using UndertaleModLib.Util;
+
+            string result = typeof(TextureWorker).FullName + typeof(MagickImage).FullName;
+            """;
+
+        Assert.True(vm.Scripting.LintScript(script, null, out string message), message);
+        Assert.True(vm.Scripting.ScriptExecutionSuccess);
+    }
+
+    [AvaloniaFact]
+    public void MainWindow_BuildsStockScriptsMenu()
+    {
+        MainWindow window = new();
+        NativeMenu? rootMenu = NativeMenu.GetMenu(window) ?? NativeDock.GetMenu(window);
+
+        NativeMenuItem scriptsItem = Assert.Single(rootMenu!.Items.OfType<NativeMenuItem>(), item => item.Header?.ToString() == "_Scripts");
+        NativeMenuItem exportersItem = Assert.Single(scriptsItem.Menu!.Items.OfType<NativeMenuItem>(), item => item.Header?.ToString() == "Resource Exporters");
+
+        Assert.Contains(exportersItem.Menu!.Items.OfType<NativeMenuItem>(), item => item.Header?.ToString() == "ExportAllSounds.csx");
+    }
+
+    [AvaloniaFact]
+    public async Task RunCommandTextAsync_RespectsFinishedMessageFlag()
+    {
+        MainViewModel vm = CreateViewModel();
+
+        vm.CommandTextBoxText = "SetUMTConsoleText(\"kept\"); SetFinishedMessage(false); \"replace\"";
+        await vm.RunCommandTextAsync();
+
+        Assert.True(vm.Scripting.ScriptExecutionSuccess);
+        Assert.Equal("kept", vm.CommandTextBoxText);
+    }
+
+    [AvaloniaFact]
+    public async Task RunCommandTextAsync_ReportsCompilationErrorsWithoutView()
+    {
+        MainViewModel vm = CreateViewModel();
+
+        vm.CommandTextBoxText = "int broken = ;";
+        await vm.RunCommandTextAsync();
+
+        Assert.False(vm.Scripting.ScriptExecutionSuccess);
+        Assert.Equal("CompilationErrorException", vm.Scripting.ScriptErrorType);
+        Assert.Contains("CS1525", vm.CommandTextBoxText);
+    }
+
+    [AvaloniaFact]
+    public async Task RunCommandTextAsync_ReportsScriptExceptionsWithoutView()
+    {
+        MainViewModel vm = CreateViewModel();
+
+        vm.CommandTextBoxText = "throw new ScriptException(\"deliberate failure\");";
+        await vm.RunCommandTextAsync();
+
+        Assert.False(vm.Scripting.ScriptExecutionSuccess);
+        Assert.Equal(nameof(ScriptException), vm.Scripting.ScriptErrorType);
+        Assert.Equal("deliberate failure", vm.CommandTextBoxText);
+    }
+
+    [AvaloniaFact]
+    public async Task SetUMTConsoleText_CanRunFromBackgroundThread()
+    {
+        MainViewModel vm = CreateViewModel();
+        ScriptGlobals globals = new(vm.Scripting, null);
+
+        await Task.Run(() => globals.SetUMTConsoleText("from background"));
+
+        Assert.Equal("from background", vm.CommandTextBoxText);
+    }
+
+    [AvaloniaFact]
+    public void ViewBackedScriptHelpers_ReturnFallbacksWithoutView()
+    {
+        MainViewModel vm = CreateViewModel();
+        ScriptGlobals globals = new(vm.Scripting, null);
+
+        Assert.Null(globals.PromptChooseDirectory());
+        Assert.Null(globals.PromptLoadFile(null, null));
+        Assert.Null(globals.PromptSaveFile("txt", "Text files|*.txt"));
+        Assert.Null(globals.ScriptInputDialog("Title", "Label", "default", "Cancel", "OK", false, false));
+        Assert.Null(globals.SimpleTextInput("Title", "Label", "default", false));
+        Assert.False(globals.ScriptQuestion("Question?"));
+
+        globals.ScriptMessage("Message");
+        globals.ScriptWarning("Warning");
+        globals.ScriptOpenURL("https://example.com");
+        globals.SetProgressBar();
+        globals.SetProgressBar("Message", "Status", 1, 10);
+        globals.SimpleTextOutput("Title", "Label", "Message", false);
+    }
+
+    [AvaloniaFact]
+    public async Task ProgressUpdater_TracksParallelProgressAndStops()
+    {
+        MainViewModel vm = CreateViewModel();
+        ScriptGlobals globals = new(vm.Scripting, null);
+
+        globals.SetProgress(0);
+        globals.StartProgressBarUpdater();
+        globals.IncrementProgressParallel();
+        globals.AddProgressParallel(4);
+        await globals.StopProgressBarUpdater();
+
+        Assert.Equal(5, globals.GetProgress());
+        Assert.True(vm.Scripting.ScriptExecutionSuccess);
+    }
+
+    [Fact]
+    public void CreateFilePickerTypes_ParsesWpfStyleScriptFilters()
+    {
+        IReadOnlyList<FilePickerFileType> types = Scripting.CreateFilePickerTypes(
+            "Sound files (*.WAV;*.OGG)|*.WAV;*.OGG|All files|*");
+
+        Assert.Equal(2, types.Count);
+        Assert.Equal("Sound files (*.WAV;*.OGG)", types[0].Name);
+        Assert.Equal(["*.WAV", "*.OGG"], types[0].Patterns);
+        Assert.Equal("All files", types[1].Name);
+        Assert.Equal(["*.*"], types[1].Patterns);
+    }
+
+    [Fact]
+    public void CreateFilePickerTypes_FallsBackForNullScriptFilters()
+    {
+        IReadOnlyList<FilePickerFileType> types = Scripting.CreateFilePickerTypes(null, FilePickerFileTypes.Data);
+
+        Assert.Same(FilePickerFileTypes.Data, types);
+    }
+
+    private static MainViewModel CreateViewModel()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<MainViewModel>();
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        MainViewModel vm = serviceProvider.GetRequiredService<MainViewModel>();
+        vm.Initialize();
+        return vm;
+    }
+
+    private static string FindRepositoryFile(string relativePath)
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            string path = Path.Combine(directory.FullName, relativePath);
+            if (File.Exists(path))
+                return path;
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException($"Could not find {relativePath}.");
+    }
+}

--- a/UndertaleModToolAvalonia.Tests/SearchInCodeViewModelTest.cs
+++ b/UndertaleModToolAvalonia.Tests/SearchInCodeViewModelTest.cs
@@ -1,0 +1,69 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace UndertaleModToolAvalonia.Tests;
+
+public class SearchInCodeViewModelTest
+{
+    [Fact]
+    public async Task SearchTask_ReturnsFalseWithoutData()
+    {
+        (MainViewModel _, SearchInCodeViewModel vm) = CreateViewModel();
+
+        bool result = await vm.SearchTask();
+
+        Assert.False(result);
+        Assert.Equal("Error: No data file loaded.", vm.StatusBarText);
+    }
+
+    [Fact]
+    public async Task SearchTask_ReturnsFalseWithoutSearchText()
+    {
+        (MainViewModel mainVM, SearchInCodeViewModel vm) = CreateViewModel();
+        await mainVM.NewData();
+
+        bool result = await vm.SearchTask();
+
+        Assert.False(result);
+        Assert.Equal("Error: No text to search.", vm.StatusBarText);
+    }
+
+    [Fact]
+    public async Task SearchTask_ReturnsFalseForInvalidRegex()
+    {
+        (MainViewModel mainVM, SearchInCodeViewModel vm) = CreateViewModel();
+        await mainVM.NewData();
+        vm.SearchText = "(";
+        vm.IsRegexSearch = true;
+
+        bool result = await vm.SearchTask();
+
+        Assert.False(result);
+        Assert.StartsWith("Error: Invalid regex", vm.StatusBarText);
+    }
+
+    [Fact]
+    public async Task SearchTask_ReturnsFalseWithoutView()
+    {
+        (MainViewModel mainVM, SearchInCodeViewModel vm) = CreateViewModel();
+        await mainVM.NewData();
+        vm.SearchText = "anything";
+
+        bool result = await vm.SearchTask();
+
+        Assert.False(result);
+        Assert.Equal("Error: Search window is not attached.", vm.StatusBarText);
+    }
+
+    private static (MainViewModel MainVM, SearchInCodeViewModel SearchVM) CreateViewModel()
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<MainViewModel>();
+        services.AddTransient<SearchInCodeViewModel>();
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        MainViewModel mainVM = serviceProvider.GetRequiredService<MainViewModel>();
+        mainVM.Initialize();
+        return (mainVM, serviceProvider.GetRequiredService<SearchInCodeViewModel>());
+    }
+}

--- a/UndertaleModToolAvalonia.Tests/SettingsFileTest.cs
+++ b/UndertaleModToolAvalonia.Tests/SettingsFileTest.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia.Styling;
+using Avalonia.Input;
+using Avalonia.Platform.Storage;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace UndertaleModToolAvalonia.Tests;
+
+public class SettingsFileTest
+{
+    [Fact]
+    public async Task SaveTask_WritesSettingsFile()
+    {
+        SettingsFile settings = CreateSettingsFile(out _);
+        string directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        string settingsPath = Path.Combine(directory, "Settings.json");
+
+        try
+        {
+            bool result = await settings.SaveTask(settingsPath);
+
+            Assert.True(result);
+            Assert.True(File.Exists(settingsPath));
+            Assert.Contains("\"Version\"", File.ReadAllText(settingsPath), StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+                Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task SaveTask_QueuesErrorWhenSaveFailsWithoutView()
+    {
+        SettingsFile settings = CreateSettingsFile(out MainViewModel vm);
+        string fileAsDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        File.WriteAllText(fileAsDirectory, "");
+
+        try
+        {
+            bool result = await settings.SaveTask(Path.Combine(fileAsDirectory, "Settings.json"));
+
+            Assert.False(result);
+            Assert.Single(vm.LazyErrorMessages);
+            Assert.StartsWith("Error when saving settings file:", vm.LazyErrorMessages[0], StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(fileAsDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task SaveTask_ShowsErrorWhenSaveFailsWithView()
+    {
+        SettingsFile settings = CreateSettingsFile(out MainViewModel vm);
+        DialogView view = new();
+        vm.View = view;
+        string fileAsDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        File.WriteAllText(fileAsDirectory, "");
+
+        try
+        {
+            bool result = await settings.SaveTask(Path.Combine(fileAsDirectory, "Settings.json"));
+
+            Assert.False(result);
+            Assert.Empty(vm.LazyErrorMessages);
+            Assert.StartsWith("Error when saving settings file:", view.LastMessage, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(fileAsDirectory);
+        }
+    }
+
+    [Fact]
+    public void TryApplyCustomStyles_ReturnsFalseWithoutApplication()
+    {
+        Styles styles = [];
+
+        bool result = SettingsFile.TryApplyCustomStyles(styles, app: null);
+
+        Assert.False(result);
+    }
+
+    private static SettingsFile CreateSettingsFile(out MainViewModel vm)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<MainViewModel>();
+        services.AddSingleton<SettingsFile>();
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        vm = serviceProvider.GetRequiredService<MainViewModel>();
+        vm.Initialize();
+        return serviceProvider.GetRequiredService<SettingsFile>();
+    }
+
+    private sealed class DialogView : IView
+    {
+        public string? LastMessage { get; private set; }
+
+        public Task<MessageWindow.Result> MessageDialog(
+            string message,
+            string? title = null,
+            MessageWindow.Buttons buttons = MessageWindow.Buttons.OK)
+        {
+            LastMessage = message;
+            return Task.FromResult(MessageWindow.Result.OK);
+        }
+
+        public Task<IReadOnlyList<IStorageFile>> OpenFileDialog(FilePickerOpenOptions options)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<IStorageFile?> SaveFileDialog(FilePickerSaveOptions options)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<IReadOnlyList<IStorageFolder>> OpenFolderDialog(FolderPickerOpenOptions options)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<bool> LaunchUriAsync(Uri uri)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<string?> TextBoxDialog(string message, string text = "", string? title = null, bool isMultiline = false, bool isReadOnly = false)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ILoaderWindow LoaderOpen()
+        {
+            throw new NotSupportedException();
+        }
+
+        public IInputElement? GetFocusedElement()
+        {
+            return null;
+        }
+    }
+}

--- a/UndertaleModToolAvalonia.Tests/ShaderViewModelTest.cs
+++ b/UndertaleModToolAvalonia.Tests/ShaderViewModelTest.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia.Input;
+using Avalonia.Platform.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using UndertaleModLib.Models;
+
+namespace UndertaleModToolAvalonia.Tests;
+
+public class ShaderViewModelTest
+{
+    [Fact]
+    public async Task ImportRawShaderDataTask_ReturnsFalseWithoutView()
+    {
+        UndertaleShaderViewModel vm = CreateViewModel(out _);
+
+        bool result = await vm.ImportRawShaderDataTask("HLSL11_VertexData");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ImportRawShaderDataTask_ReturnsFalseWhenPickerIsCanceled()
+    {
+        UndertaleShaderViewModel vm = CreateViewModel(out MainViewModel mainVM);
+        DialogView view = new();
+        mainVM.View = view;
+
+        bool result = await vm.ImportRawShaderDataTask("HLSL11_VertexData");
+
+        Assert.False(result);
+        Assert.NotNull(view.LastOpenFileOptions);
+        Assert.Equal("Import shader", view.LastOpenFileOptions.Title);
+    }
+
+    [Fact]
+    public async Task ExportRawShaderDataTask_ReturnsFalseWithoutView()
+    {
+        UndertaleShaderViewModel vm = CreateViewModel(out _);
+        vm.Shader.HLSL11_VertexData = new UndertaleShader.UndertaleRawShaderData { IsNull = false, Data = [1, 2, 3] };
+
+        bool result = await vm.ExportRawShaderDataTask("HLSL11_VertexData");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ExportRawShaderDataTask_ReturnsFalseWhenDataIsMissing()
+    {
+        UndertaleShaderViewModel vm = CreateViewModel(out MainViewModel mainVM);
+        mainVM.View = new DialogView();
+
+        bool result = await vm.ExportRawShaderDataTask("HLSL11_VertexData");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ExportRawShaderDataTask_ReturnsFalseWhenPickerIsCanceled()
+    {
+        UndertaleShaderViewModel vm = CreateViewModel(out MainViewModel mainVM);
+        DialogView view = new();
+        mainVM.View = view;
+        vm.Shader.HLSL11_VertexData = new UndertaleShader.UndertaleRawShaderData { IsNull = false, Data = [1, 2, 3] };
+
+        bool result = await vm.ExportRawShaderDataTask("HLSL11_VertexData");
+
+        Assert.False(result);
+        Assert.NotNull(view.LastSaveFileOptions);
+        Assert.Equal("Export shader", view.LastSaveFileOptions.Title);
+    }
+
+    private static UndertaleShaderViewModel CreateViewModel(out MainViewModel mainVM)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<MainViewModel>();
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        mainVM = serviceProvider.GetRequiredService<MainViewModel>();
+        mainVM.Initialize();
+
+        UndertaleShader shader = new()
+        {
+            Name = new UndertaleString("shd_test"),
+        };
+
+        return new UndertaleShaderViewModel(shader, serviceProvider);
+    }
+
+    private sealed class DialogView : IView
+    {
+        public FilePickerOpenOptions? LastOpenFileOptions { get; private set; }
+        public FilePickerSaveOptions? LastSaveFileOptions { get; private set; }
+
+        public Task<MessageWindow.Result> MessageDialog(
+            string message,
+            string? title = null,
+            MessageWindow.Buttons buttons = MessageWindow.Buttons.OK)
+        {
+            return Task.FromResult(MessageWindow.Result.OK);
+        }
+
+        public Task<IReadOnlyList<IStorageFile>> OpenFileDialog(FilePickerOpenOptions options)
+        {
+            LastOpenFileOptions = options;
+            return Task.FromResult<IReadOnlyList<IStorageFile>>([]);
+        }
+
+        public Task<IStorageFile?> SaveFileDialog(FilePickerSaveOptions options)
+        {
+            LastSaveFileOptions = options;
+            return Task.FromResult<IStorageFile?>(null);
+        }
+
+        public Task<IReadOnlyList<IStorageFolder>> OpenFolderDialog(FolderPickerOpenOptions options)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<bool> LaunchUriAsync(Uri uri)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<string?> TextBoxDialog(string message, string text = "", string? title = null, bool isMultiline = false, bool isReadOnly = false)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ILoaderWindow LoaderOpen()
+        {
+            throw new NotSupportedException();
+        }
+
+        public IInputElement? GetFocusedElement()
+        {
+            return null;
+        }
+    }
+}

--- a/UndertaleModToolAvalonia.Tests/SoundViewModelTest.cs
+++ b/UndertaleModToolAvalonia.Tests/SoundViewModelTest.cs
@@ -1,0 +1,51 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using UndertaleModLib.Models;
+
+namespace UndertaleModToolAvalonia.Tests;
+
+public class SoundViewModelTest
+{
+    [Fact]
+    public async Task PlayAudioTask_ReturnsFalseWithoutAudioFile()
+    {
+        UndertaleSoundViewModel vm = CreateViewModel(audio: null);
+
+        bool result = await vm.PlayAudioTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task PlayAudioTask_ReturnsFalseWithoutAudioData()
+    {
+        UndertaleEmbeddedAudio audio = new()
+        {
+            Name = new UndertaleString("audio_test"),
+            Data = [],
+        };
+        UndertaleSoundViewModel vm = CreateViewModel(audio);
+
+        bool result = await vm.PlayAudioTask();
+
+        Assert.False(result);
+    }
+
+    private static UndertaleSoundViewModel CreateViewModel(UndertaleEmbeddedAudio? audio)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<MainViewModel>();
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        MainViewModel mainVM = serviceProvider.GetRequiredService<MainViewModel>();
+        mainVM.Initialize();
+
+        UndertaleSound sound = new()
+        {
+            Name = new UndertaleString("snd_test"),
+            AudioFile = audio,
+        };
+
+        return new UndertaleSoundViewModel(sound, serviceProvider);
+    }
+}

--- a/UndertaleModToolAvalonia.Tests/SpriteViewModelTest.cs
+++ b/UndertaleModToolAvalonia.Tests/SpriteViewModelTest.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia.Input;
+using Avalonia.Platform.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using UndertaleModLib.Models;
+
+namespace UndertaleModToolAvalonia.Tests;
+
+public class SpriteViewModelTest
+{
+    [Fact]
+    public async Task ExportAllTexturesAsPNGsTask_ReturnsFalseWithoutView()
+    {
+        UndertaleSpriteViewModel vm = CreateViewModel(out _);
+
+        bool result = await vm.ExportAllTexturesAsPNGsTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ExportAllTexturesAsPNGsTask_ReturnsFalseWhenFolderPickerIsCanceled()
+    {
+        UndertaleSpriteViewModel vm = CreateViewModel(out MainViewModel mainVM);
+        DialogView view = new();
+        mainVM.View = view;
+
+        bool result = await vm.ExportAllTexturesAsPNGsTask();
+
+        Assert.False(result);
+        Assert.NotNull(view.LastOpenFolderOptions);
+        Assert.Equal("Export all textures into folder", view.LastOpenFolderOptions.Title);
+    }
+
+    [Fact]
+    public async Task ImportCollisionMaskDataTask_ReturnsFalseWithoutView()
+    {
+        UndertaleSpriteViewModel vm = CreateViewModel(out _);
+
+        bool result = await vm.ImportCollisionMaskDataTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ImportCollisionMaskDataTask_ReturnsFalseWithoutSelectedMask()
+    {
+        UndertaleSpriteViewModel vm = CreateViewModel(out _, includeMask: false);
+
+        bool result = await vm.ImportCollisionMaskDataTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ImportCollisionMaskDataTask_ReturnsFalseWhenPickerIsCanceled()
+    {
+        UndertaleSpriteViewModel vm = CreateViewModel(out MainViewModel mainVM);
+        DialogView view = new();
+        mainVM.View = view;
+
+        bool result = await vm.ImportCollisionMaskDataTask();
+
+        Assert.False(result);
+        Assert.NotNull(view.LastOpenFileOptions);
+        Assert.Equal("Import collision mask data", view.LastOpenFileOptions.Title);
+    }
+
+    [Fact]
+    public async Task ExportCollisionMaskDataTask_ReturnsFalseWithoutView()
+    {
+        UndertaleSpriteViewModel vm = CreateViewModel(out _);
+
+        bool result = await vm.ExportCollisionMaskDataTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ExportCollisionMaskDataTask_ReturnsFalseWithoutSelectedMask()
+    {
+        UndertaleSpriteViewModel vm = CreateViewModel(out _, includeMask: false);
+
+        bool result = await vm.ExportCollisionMaskDataTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ExportCollisionMaskDataTask_ReturnsFalseWhenPickerIsCanceled()
+    {
+        UndertaleSpriteViewModel vm = CreateViewModel(out MainViewModel mainVM);
+        DialogView view = new();
+        mainVM.View = view;
+
+        bool result = await vm.ExportCollisionMaskDataTask();
+
+        Assert.False(result);
+        Assert.NotNull(view.LastSaveFileOptions);
+        Assert.Equal("Export collision mask data", view.LastSaveFileOptions.Title);
+    }
+
+    private static UndertaleSpriteViewModel CreateViewModel(out MainViewModel mainVM, bool includeMask = true)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<MainViewModel>();
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        mainVM = serviceProvider.GetRequiredService<MainViewModel>();
+        mainVM.Initialize();
+
+        UndertaleSprite sprite = new()
+        {
+            Name = new UndertaleString("spr_test"),
+        };
+
+        if (includeMask)
+            sprite.CollisionMasks.Add(new UndertaleSprite.MaskEntry([0], 1, 1));
+
+        return new UndertaleSpriteViewModel(sprite, serviceProvider);
+    }
+
+    private sealed class DialogView : IView
+    {
+        public FilePickerOpenOptions? LastOpenFileOptions { get; private set; }
+        public FilePickerSaveOptions? LastSaveFileOptions { get; private set; }
+        public FolderPickerOpenOptions? LastOpenFolderOptions { get; private set; }
+
+        public Task<MessageWindow.Result> MessageDialog(
+            string message,
+            string? title = null,
+            MessageWindow.Buttons buttons = MessageWindow.Buttons.OK)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<IReadOnlyList<IStorageFile>> OpenFileDialog(FilePickerOpenOptions options)
+        {
+            LastOpenFileOptions = options;
+            return Task.FromResult<IReadOnlyList<IStorageFile>>([]);
+        }
+
+        public Task<IStorageFile?> SaveFileDialog(FilePickerSaveOptions options)
+        {
+            LastSaveFileOptions = options;
+            return Task.FromResult<IStorageFile?>(null);
+        }
+
+        public Task<IReadOnlyList<IStorageFolder>> OpenFolderDialog(FolderPickerOpenOptions options)
+        {
+            LastOpenFolderOptions = options;
+            return Task.FromResult<IReadOnlyList<IStorageFolder>>([]);
+        }
+
+        public Task<bool> LaunchUriAsync(Uri uri)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<string?> TextBoxDialog(string message, string text = "", string? title = null, bool isMultiline = false, bool isReadOnly = false)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ILoaderWindow LoaderOpen()
+        {
+            throw new NotSupportedException();
+        }
+
+        public IInputElement? GetFocusedElement()
+        {
+            return null;
+        }
+    }
+}

--- a/UndertaleModToolAvalonia.Tests/TexturePageItemViewModelTest.cs
+++ b/UndertaleModToolAvalonia.Tests/TexturePageItemViewModelTest.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia.Input;
+using Avalonia.Platform.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using UndertaleModLib.Models;
+
+namespace UndertaleModToolAvalonia.Tests;
+
+public class TexturePageItemViewModelTest
+{
+    [Fact]
+    public async Task ImportImageTask_ReturnsFalseWithoutView()
+    {
+        UndertaleTexturePageItemViewModel vm = CreateViewModel(out _);
+
+        bool result = await vm.ImportImageTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ImportImageTask_ReturnsFalseWhenPickerIsCanceled()
+    {
+        UndertaleTexturePageItemViewModel vm = CreateViewModel(out MainViewModel mainVM);
+        DialogView view = new();
+        mainVM.View = view;
+
+        bool result = await vm.ImportImageTask();
+
+        Assert.False(result);
+        Assert.NotNull(view.LastOpenFileOptions);
+        Assert.Equal("Import PNG", view.LastOpenFileOptions.Title);
+    }
+
+    [Fact]
+    public async Task ExportImageTask_ReturnsFalseWithoutView()
+    {
+        UndertaleTexturePageItemViewModel vm = CreateViewModel(out _);
+
+        bool result = await vm.ExportImageTask();
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task ExportImageTask_ReturnsFalseWhenPickerIsCanceled()
+    {
+        UndertaleTexturePageItemViewModel vm = CreateViewModel(out MainViewModel mainVM);
+        DialogView view = new();
+        mainVM.View = view;
+
+        bool result = await vm.ExportImageTask();
+
+        Assert.False(result);
+        Assert.NotNull(view.LastSaveFileOptions);
+        Assert.Equal("Export PNG", view.LastSaveFileOptions.Title);
+    }
+
+    private static UndertaleTexturePageItemViewModel CreateViewModel(out MainViewModel mainVM)
+    {
+        ServiceCollection services = new();
+        services.AddSingleton<MainViewModel>();
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        mainVM = serviceProvider.GetRequiredService<MainViewModel>();
+        mainVM.Initialize();
+
+        UndertaleTexturePageItem item = new()
+        {
+            Name = new UndertaleString("PageItem 0"),
+        };
+
+        return new UndertaleTexturePageItemViewModel(item, serviceProvider);
+    }
+
+    private sealed class DialogView : IView
+    {
+        public FilePickerOpenOptions? LastOpenFileOptions { get; private set; }
+        public FilePickerSaveOptions? LastSaveFileOptions { get; private set; }
+
+        public Task<MessageWindow.Result> MessageDialog(
+            string message,
+            string? title = null,
+            MessageWindow.Buttons buttons = MessageWindow.Buttons.OK)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<IReadOnlyList<IStorageFile>> OpenFileDialog(FilePickerOpenOptions options)
+        {
+            LastOpenFileOptions = options;
+            return Task.FromResult<IReadOnlyList<IStorageFile>>([]);
+        }
+
+        public Task<IStorageFile?> SaveFileDialog(FilePickerSaveOptions options)
+        {
+            LastSaveFileOptions = options;
+            return Task.FromResult<IStorageFile?>(null);
+        }
+
+        public Task<IReadOnlyList<IStorageFolder>> OpenFolderDialog(FolderPickerOpenOptions options)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<bool> LaunchUriAsync(Uri uri)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<string?> TextBoxDialog(string message, string text = "", string? title = null, bool isMultiline = false, bool isReadOnly = false)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ILoaderWindow LoaderOpen()
+        {
+            throw new NotSupportedException();
+        }
+
+        public IInputElement? GetFocusedElement()
+        {
+            return null;
+        }
+    }
+}

--- a/UndertaleModToolAvalonia.Tests/ViewGuardTest.cs
+++ b/UndertaleModToolAvalonia.Tests/ViewGuardTest.cs
@@ -1,0 +1,32 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+
+namespace UndertaleModToolAvalonia.Tests;
+
+public class ViewGuardTest
+{
+    [AvaloniaFact]
+    public void RequireTopLevel_ThrowsActionableErrorWhenViewIsDetached()
+    {
+        UserControl view = new();
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => view.RequireTopLevel("TestOperation"));
+
+        Assert.Contains("TestOperation", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("top-level window", exception.Message, StringComparison.Ordinal);
+    }
+
+    [AvaloniaFact]
+    public void RequireWindow_ThrowsActionableErrorWhenViewIsDetached()
+    {
+        UserControl view = new();
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(
+            () => view.RequireWindow("TestOperation"));
+
+        Assert.Contains("TestOperation", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("window", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/UndertaleModToolAvalonia/App.axaml.cs
+++ b/UndertaleModToolAvalonia/App.axaml.cs
@@ -11,6 +11,7 @@ public partial class App : Application
 {
     public static IServiceProvider Services = null!;
     public static IStyle? CurrentCustomStyles = null;
+    private static bool servicesDisposed;
 
     public override void Initialize()
     {
@@ -24,6 +25,7 @@ public partial class App : Application
         collection.AddSingleton<MainViewModel>();
 
         Services = collection.BuildServiceProvider();
+        servicesDisposed = false;
 
         MainViewModel vm = Services.GetRequiredService<MainViewModel>();
         vm.Initialize();
@@ -34,8 +36,21 @@ public partial class App : Application
             {
                 DataContext = vm,
             };
+
+            desktop.Exit += (_, _) => DisposeServices();
         }
 
         base.OnFrameworkInitializationCompleted();
+    }
+
+    private static void DisposeServices()
+    {
+        if (servicesDisposed)
+            return;
+
+        servicesDisposed = true;
+
+        if (Services is IDisposable disposable)
+            disposable.Dispose();
     }
 }

--- a/UndertaleModToolAvalonia/Controls/EditableDataGrid.axaml.cs
+++ b/UndertaleModToolAvalonia/Controls/EditableDataGrid.axaml.cs
@@ -107,7 +107,7 @@ public partial class EditableDataGrid : UserControl
         }
         else
         {
-            throw new InvalidOperationException();
+            throw new InvalidOperationException("EditableDataGrid requires ItemFactory to be a Func<object> or Func<int, object> before adding items.");
         }
 
         ItemsSource.Add(item);

--- a/UndertaleModToolAvalonia/Controls/FlagsBoxView.axaml.cs
+++ b/UndertaleModToolAvalonia/Controls/FlagsBoxView.axaml.cs
@@ -13,9 +13,9 @@ namespace UndertaleModToolAvalonia;
 
 public partial class FlagsBoxView : UserControl
 {
-    public static readonly StyledProperty<dynamic> ValueProperty = AvaloniaProperty.Register<FlagsBoxView, dynamic>(
+    public static readonly StyledProperty<object?> ValueProperty = AvaloniaProperty.Register<FlagsBoxView, object?>(
         nameof(Value), defaultBindingMode: Avalonia.Data.BindingMode.TwoWay);
-    public dynamic Value
+    public object? Value
     {
         get { return GetValue(ValueProperty); }
         set { SetValue(ValueProperty, value); }
@@ -78,17 +78,20 @@ public partial class FlagsBoxView : UserControl
 
     public void Checked_IsCheckChanged(object? sender, RoutedEventArgs e)
     {
-        CheckBox checkBox = (sender as CheckBox)!;
+        if (Value is null || sender is not CheckBox checkBox)
+            return;
+
         if (checkBox.DataContext is Flag flag)
         {
             if (checkBox.IsChecked == true)
             {
-                Value |= flag.FlagEnum;
+                dynamic value = Value!;
+                Value = value | flag.FlagEnum;
             }
             else
             {
-                Value &= ~flag.FlagEnum;
-                Enum test = (Enum)Enum.ToObject(Value.GetType(), 42);
+                dynamic value = Value!;
+                Value = value & ~flag.FlagEnum;
             }
         }
     }
@@ -107,10 +110,14 @@ public class FlagEnumToStringConverter : IValueConverter
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        DataValidationErrors.SetError(View!.ValueTextBox, null);
+        FlagsBoxView? view = View;
+        TextBox? valueTextBox = view?.ValueTextBox;
+        if (valueTextBox is not null)
+            DataValidationErrors.SetError(valueTextBox, null);
+
         if (value is string valueString)
         {
-            if (Enum.TryParse(View!.Value.GetType(), valueString, out object? result))
+            if (view?.Value is not null && Enum.TryParse(view.Value.GetType(), valueString, out object? result))
             {
                 return result;
             }
@@ -118,7 +125,8 @@ public class FlagEnumToStringConverter : IValueConverter
             {
                 // Can't do this because the type is dynamic, so the notification will be stored in Value. This may actually be a bug with Avalonia, I'm not sure.
                 // return new BindingNotification(new InvalidCastException(), BindingErrorType.Error);
-                DataValidationErrors.SetError(View!.ValueTextBox, new InvalidCastException());
+                if (valueTextBox is not null)
+                    DataValidationErrors.SetError(valueTextBox, new InvalidCastException());
                 return BindingOperations.DoNothing;
 
             }

--- a/UndertaleModToolAvalonia/Controls/SKImageViewer.cs
+++ b/UndertaleModToolAvalonia/Controls/SKImageViewer.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data;
@@ -33,6 +33,49 @@ public class SKImageViewer : Control
     {
         get => GetValue(BindingsProperty);
         set => SetValue(BindingsProperty, value);
+    }
+
+    public static readonly StyledProperty<IReadOnlyList<UndertaleTexturePageItem>?> TexturePageItemsProperty =
+        AvaloniaProperty.Register<SKImageViewer, IReadOnlyList<UndertaleTexturePageItem>?>(nameof(TexturePageItems));
+
+    public IReadOnlyList<UndertaleTexturePageItem>? TexturePageItems
+    {
+        get => GetValue(TexturePageItemsProperty);
+        set => SetValue(TexturePageItemsProperty, value);
+    }
+
+    public static readonly StyledProperty<UndertaleTexturePageItem?> SelectedTexturePageItemProperty =
+        AvaloniaProperty.Register<SKImageViewer, UndertaleTexturePageItem?>(
+            nameof(SelectedTexturePageItem),
+            defaultBindingMode: BindingMode.TwoWay);
+
+    public UndertaleTexturePageItem? SelectedTexturePageItem
+    {
+        get => GetValue(SelectedTexturePageItemProperty);
+        set => SetValue(SelectedTexturePageItemProperty, value);
+    }
+
+    public static readonly StyledProperty<double> ZoomProperty =
+        AvaloniaProperty.Register<SKImageViewer, double>(
+            nameof(Zoom),
+            defaultValue: 1,
+            defaultBindingMode: BindingMode.TwoWay);
+
+    public double Zoom
+    {
+        get => GetValue(ZoomProperty);
+        set => SetValue(ZoomProperty, ClampZoom(value));
+    }
+
+    public static readonly StyledProperty<bool> IsRenderingEnabledProperty =
+        AvaloniaProperty.Register<SKImageViewer, bool>(
+            nameof(IsRenderingEnabled),
+            defaultValue: true);
+
+    public bool IsRenderingEnabled
+    {
+        get => GetValue(IsRenderingEnabledProperty);
+        set => SetValue(IsRenderingEnabledProperty, value);
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -85,8 +128,15 @@ public class SKImageViewer : Control
 
             Invalidate();
         }
-        else if (change.Property == BindingsProperty)
+        else if (change.Property == BindingsProperty ||
+                 change.Property == TexturePageItemsProperty ||
+                 change.Property == SelectedTexturePageItemProperty ||
+                 change.Property == ZoomProperty ||
+                 change.Property == IsRenderingEnabledProperty)
         {
+            if (change.Property == ZoomProperty)
+                Zoom = ClampZoom(Zoom);
+
             Invalidate();
         }
     }
@@ -97,6 +147,42 @@ public class SKImageViewer : Control
     {
         ClipToBounds = true;
         customDrawOperation = new CustomDrawOperation();
+        PointerReleased += SKImageViewer_PointerReleased;
+        PointerWheelChanged += SKImageViewer_PointerWheelChanged;
+    }
+
+    private void SKImageViewer_PointerReleased(object? sender, Avalonia.Input.PointerReleasedEventArgs e)
+    {
+        if (!IsRenderingEnabled ||
+            e.InitialPressMouseButton != Avalonia.Input.MouseButton.Left ||
+            TexturePageItems is null)
+            return;
+
+        Point pointerPosition = e.GetPosition(this);
+        Point point = new(pointerPosition.X / Zoom, pointerPosition.Y / Zoom);
+        SelectedTexturePageItem = TexturePageItems
+            .Where(item => item.SourceWidth > 0 && item.SourceHeight > 0)
+            .Where(item => point.X >= item.SourceX && point.X < item.SourceX + item.SourceWidth &&
+                           point.Y >= item.SourceY && point.Y < item.SourceY + item.SourceHeight)
+            .OrderBy(item => (long)item.SourceWidth * item.SourceHeight)
+            .FirstOrDefault();
+    }
+
+    private void SKImageViewer_PointerWheelChanged(object? sender, Avalonia.Input.PointerWheelEventArgs e)
+    {
+        if (e.Delta.Y == 0)
+            return;
+
+        Zoom = ClampZoom(Zoom * (e.Delta.Y > 0 ? 2 : 0.5));
+        e.Handled = true;
+    }
+
+    static double ClampZoom(double zoom)
+    {
+        if (double.IsNaN(zoom) || double.IsInfinity(zoom))
+            return 1;
+
+        return Math.Clamp(zoom, 0.125, 32);
     }
 
     void Invalidate()
@@ -111,14 +197,18 @@ public class SKImageViewer : Control
 
     Size GetSize()
     {
-        if (Image is UndertaleTexturePageItem texturePageItem)
-            return new Size(texturePageItem.BoundingWidth, texturePageItem.BoundingHeight);
-        else if (Image is GMImage gmImage)
-            return new Size(gmImage.Width, gmImage.Height);
-        else if (Image is UndertaleSprite.MaskEntry maskEntry)
-            return new Size(maskEntry.Width, maskEntry.Height);
+        Size size;
 
-        return new Size(0, 0);
+        if (Image is UndertaleTexturePageItem texturePageItem)
+            size = new Size(texturePageItem.BoundingWidth, texturePageItem.BoundingHeight);
+        else if (Image is GMImage gmImage)
+            size = new Size(gmImage.Width, gmImage.Height);
+        else if (Image is UndertaleSprite.MaskEntry maskEntry)
+            size = new Size(maskEntry.Width, maskEntry.Height);
+        else
+            size = new Size(0, 0);
+
+        return size * Zoom;
     }
 
     protected override Size MeasureOverride(Size availableSize)
@@ -131,6 +221,10 @@ public class SKImageViewer : Control
         Size size = GetSize();
         customDrawOperation.Bounds = new Rect(0, 0, size.Width, size.Height);
         customDrawOperation.Image = Image;
+        customDrawOperation.TexturePageItems = TexturePageItems;
+        customDrawOperation.SelectedTexturePageItem = SelectedTexturePageItem;
+        customDrawOperation.Zoom = Zoom;
+        customDrawOperation.IsRenderingEnabled = IsRenderingEnabled;
 
         context.Custom(customDrawOperation);
     }
@@ -140,6 +234,10 @@ public class SKImageViewer : Control
         public Rect Bounds { get; set; }
 
         public object? Image;
+        public IReadOnlyList<UndertaleTexturePageItem>? TexturePageItems;
+        public UndertaleTexturePageItem? SelectedTexturePageItem;
+        public double Zoom = 1;
+        public bool IsRenderingEnabled = true;
 
         readonly MainViewModel mainVM = App.Services.GetRequiredService<MainViewModel>();
 
@@ -164,16 +262,28 @@ public class SKImageViewer : Control
                 using var lease = leaseFeature.Lease();
                 SKCanvas canvas = lease.SkCanvas;
                 canvas.Save();
+                double zoom = ClampZoom(Zoom);
+                canvas.Scale((float)zoom);
+
+                float naturalWidth = (float)(Bounds.Width / zoom);
+                float naturalHeight = (float)(Bounds.Height / zoom);
+
+                if (!IsRenderingEnabled)
+                {
+                    RenderPlaceholder(canvas, naturalWidth, naturalHeight);
+                    canvas.Restore();
+                    return;
+                }
 
                 // Checkered background
                 int gridSize = 8;
-                SKPaint gridColor1 = new SKPaint { Color = new SKColor(102, 102, 102) };
-                SKPaint gridColor2 = new SKPaint { Color = new SKColor(153, 153, 153) };
+                using SKPaint gridColor1 = new() { Color = new SKColor(102, 102, 102) };
+                using SKPaint gridColor2 = new() { Color = new SKColor(153, 153, 153) };
 
-                canvas.DrawRect(SKRect.Create(0, 0, (float)Bounds.Width, (float)Bounds.Height), gridColor1);
+                canvas.DrawRect(SKRect.Create(0, 0, naturalWidth, naturalHeight), gridColor1);
 
-                for (int x = 0; x < Bounds.Width / gridSize; x++)
-                    for (int y = 0; y < Bounds.Height / gridSize; y++)
+                for (int x = 0; x < naturalWidth / gridSize; x++)
+                    for (int y = 0; y < naturalHeight / gridSize; y++)
                     {
                         if ((x + y) % 2 != 0)
                             canvas.DrawRect(SKRect.Create(x * gridSize, y * gridSize, gridSize, gridSize), gridColor2);
@@ -181,14 +291,37 @@ public class SKImageViewer : Control
 
                 // Image
                 RenderImage(canvas);
+                RenderTexturePageItemSelection(canvas);
 
                 canvas.Restore();
             }
-            catch (Exception e)
+            catch (Exception)
             {
-                Debugger.Break();
                 throw;
             }
+        }
+
+        static void RenderPlaceholder(SKCanvas canvas, float width, float height)
+        {
+            if (width <= 0 || height <= 0)
+                return;
+
+            using SKPaint fillPaint = new()
+            {
+                Color = new SKColor(35, 39, 45),
+                Style = SKPaintStyle.Fill
+            };
+            using SKPaint strokePaint = new()
+            {
+                Color = new SKColor(78, 86, 96),
+                Style = SKPaintStyle.Stroke,
+                StrokeWidth = 1,
+                IsAntialias = false
+            };
+
+            SKRect rect = SKRect.Create(0, 0, width, height);
+            canvas.DrawRect(rect, fillPaint);
+            canvas.DrawRect(rect, strokePaint);
         }
 
         public void RenderImage(SKCanvas canvas)
@@ -233,6 +366,38 @@ public class SKImageViewer : Control
                 SKImage image = SKImage.FromPixelCopy(new SKImageInfo(maskEntry.Width, maskEntry.Height, SKColorType.Gray8), pixels);
                 canvas.DrawImage(image, 0, 0);
             }
+        }
+
+        void RenderTexturePageItemSelection(SKCanvas canvas)
+        {
+            if (SelectedTexturePageItem is null || TexturePageItems is null || Image is not GMImage gmImage)
+                return;
+
+            if (!TexturePageItems.Contains(SelectedTexturePageItem) ||
+                SelectedTexturePageItem.TexturePage?.TextureData?.Image != gmImage)
+                return;
+
+            SKRect rect = SKRect.Create(
+                SelectedTexturePageItem.SourceX,
+                SelectedTexturePageItem.SourceY,
+                SelectedTexturePageItem.SourceWidth,
+                SelectedTexturePageItem.SourceHeight);
+
+            using SKPaint fillPaint = new()
+            {
+                Color = new SKColor(73, 130, 188, 72),
+                Style = SKPaintStyle.Fill
+            };
+            using SKPaint strokePaint = new()
+            {
+                Color = new SKColor(124, 184, 255, 220),
+                Style = SKPaintStyle.Stroke,
+                StrokeWidth = 2,
+                IsAntialias = false
+            };
+
+            canvas.DrawRect(rect, fillPaint);
+            canvas.DrawRect(rect, strokePaint);
         }
     }
 }

--- a/UndertaleModToolAvalonia/Controls/UndertalePathEditor.cs
+++ b/UndertaleModToolAvalonia/Controls/UndertalePathEditor.cs
@@ -46,8 +46,7 @@ public class UndertalePathEditor : Control
 
         context.DrawGeometry(null, new Pen(pathBrush, thickness: 2), geometry);
 
-        TopLevel topLevel = TopLevel.GetTopLevel(this)!;
-        topLevel.RequestAnimationFrame(_ =>
+        TopLevel.GetTopLevel(this)?.RequestAnimationFrame(_ =>
         {
             InvalidateMeasure();
             InvalidateVisual();

--- a/UndertaleModToolAvalonia/Controls/UndertaleResourceReferenceView.axaml.cs
+++ b/UndertaleModToolAvalonia/Controls/UndertaleResourceReferenceView.axaml.cs
@@ -57,7 +57,9 @@ public partial class UndertaleResourceReferenceView : UserControl
 
         if (change.Property == ReferenceTypeProperty)
         {
-            this.Find<TextBox>("TextBox")!.PlaceholderText = "(" + ReferenceType.Name + " reference)";
+            TextBox? textBox = this.Find<TextBox>("TextBox");
+            if (textBox is not null)
+                textBox.PlaceholderText = "(" + ReferenceType.Name + " reference)";
         }
     }
 
@@ -87,19 +89,24 @@ public partial class UndertaleResourceReferenceView : UserControl
 
     public void Open()
     {
-        MainViewModel mainView = (this.FindLogicalAncestorOfType<MainView>()!.DataContext as MainViewModel)!;
-        mainView.TabOpen(Reference);
+        if (TryGetMainViewModel() is { } mainView)
+            mainView.TabOpen(Reference);
     }
 
     public void OpenInNewTab()
     {
-        MainViewModel mainView = (this.FindLogicalAncestorOfType<MainView>()!.DataContext as MainViewModel)!;
-        mainView.TabOpen(Reference, inNewTab: true);
+        if (TryGetMainViewModel() is { } mainView)
+            mainView.TabOpen(Reference, inNewTab: true);
     }
 
     public void Remove()
     {
         Reference = null;
+    }
+
+    private MainViewModel? TryGetMainViewModel()
+    {
+        return this.FindLogicalAncestorOfType<MainView>()?.DataContext as MainViewModel;
     }
 }
 

--- a/UndertaleModToolAvalonia/Controls/UndertaleRoomEditor.cs
+++ b/UndertaleModToolAvalonia/Controls/UndertaleRoomEditor.cs
@@ -44,6 +44,17 @@ public class UndertaleRoomEditor : Control
 
     readonly RoomRenderer rendererInstance = new();
 
+    public static readonly StyledProperty<bool> IsRenderingEnabledProperty =
+        AvaloniaProperty.Register<UndertaleRoomEditor, bool>(
+            nameof(IsRenderingEnabled),
+            defaultValue: true);
+
+    public bool IsRenderingEnabled
+    {
+        get => GetValue(IsRenderingEnabledProperty);
+        set => SetValue(IsRenderingEnabledProperty, value);
+    }
+
     double customDrawOperationTime;
 
     // Room controls
@@ -71,11 +82,19 @@ public class UndertaleRoomEditor : Control
         Interaction.SetBehaviors(this, [new ContextDropBehavior() { Handler = new UndertaleReferenceDropHandler() }]);
     }
 
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == IsRenderingEnabledProperty)
+            InvalidateVisual();
+    }
+
     protected override void OnDataContextChanged(EventArgs e)
     {
         base.OnDataContextChanged(e);
 
-        vm = (DataContext as UndertaleRoomViewModel)!;
+        vm = DataContext as UndertaleRoomViewModel;
         vm?.Room.SetupRoom();
 
         translation = new(0, 0);
@@ -84,10 +103,14 @@ public class UndertaleRoomEditor : Control
 
     protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
+        if (!IsRenderingEnabled || vm is null)
+            return;
+
+        UndertaleRoomViewModel roomVM = vm;
         PointerPoint pointerPoint = e.GetCurrentPoint(this);
         InteractionMode interactionMode = GetInteractionMode();
 
-        var roomItems = Updater.MakeRoomItems(vm!.Room);
+        var roomItems = Updater.MakeRoomItems(roomVM.Room);
 
         if (pointerPoint.Properties.IsMiddleButtonPressed)
         {
@@ -108,7 +131,7 @@ public class UndertaleRoomEditor : Control
             {
                 if (pointerPoint.Properties.IsLeftButtonPressed)
                 {
-                    SetLayerTileAtPointer(tilesLayer, vm!.SelectedTileData);
+                    SetLayerTileAtPointer(tilesLayer, roomVM.SelectedTileData);
                 }
                 else if (pointerPoint.Properties.IsRightButtonPressed)
                 {
@@ -120,11 +143,15 @@ public class UndertaleRoomEditor : Control
 
     protected override void OnPointerMoved(PointerEventArgs e)
     {
+        if (!IsRenderingEnabled || vm is null)
+            return;
+
+        UndertaleRoomViewModel roomVM = vm;
         PointerPoint pointerPoint = e.GetCurrentPoint(this);
         InteractionMode interactionMode = GetInteractionMode();
         UndertaleRoom.Layer? tilesLayer = GetSelectedTilesLayer();
 
-        var roomItems = Updater.MakeRoomItems(vm!.Room);
+        var roomItems = Updater.MakeRoomItems(roomVM.Room);
 
         pointerPosition = e.GetPosition(this);
         pointerPositionInRoom = (pointerPosition - translation) / scaling;
@@ -136,7 +163,7 @@ public class UndertaleRoomEditor : Control
             if (pointerPoint.Properties.IsLeftButtonPressed)
             {
                 ItemMoveOnMoved(roomItems);
-                roomItems = Updater.MakeRoomItems(vm!.Room);
+                roomItems = Updater.MakeRoomItems(roomVM.Room);
             }
         }
         else if (interactionMode == InteractionMode.Tiles)
@@ -145,7 +172,7 @@ public class UndertaleRoomEditor : Control
             {
                 if (pointerPoint.Properties.IsLeftButtonPressed)
                 {
-                    SetLayerTileAtPointer(tilesLayer, vm!.SelectedTileData);
+                    SetLayerTileAtPointer(tilesLayer, roomVM.SelectedTileData);
                 }
                 else if (pointerPoint.Properties.IsRightButtonPressed)
                 {
@@ -166,11 +193,15 @@ public class UndertaleRoomEditor : Control
             ItemHoverOnMoved(roomItems);
         }
 
-        vm!.StatusText = $"({Math.Floor(pointerPositionInRoom.X)}, {Math.Floor(pointerPositionInRoom.Y)})";
+        roomVM.StatusText = $"({Math.Floor(pointerPositionInRoom.X)}, {Math.Floor(pointerPositionInRoom.Y)})";
     }
 
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
     {
+        if (!IsRenderingEnabled || vm is null)
+            return;
+
+        UndertaleRoomViewModel roomVM = vm;
         InteractionMode interactionMode = GetInteractionMode();
         UndertaleRoom.Layer? tilesLayer = GetSelectedTilesLayer();
 
@@ -184,7 +215,7 @@ public class UndertaleRoomEditor : Control
                     {
                         uint? tile = GetLayerTileAtPointer(tilesLayer);
                         if (tile is not null)
-                            vm!.SelectedTileData = (uint)tile;
+                            roomVM.SelectedTileData = (uint)tile;
                     }
                 }
             }
@@ -195,6 +226,9 @@ public class UndertaleRoomEditor : Control
 
     protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
     {
+        if (!IsRenderingEnabled || vm is null)
+            return;
+
         if (e.Delta.Y > 0)
         {
             translation *= 2;
@@ -210,24 +244,30 @@ public class UndertaleRoomEditor : Control
 
         translation = new Vector(Math.Round(translation.X), Math.Round(translation.Y));
 
-        vm!.Zoom = scaling;
+        vm.Zoom = scaling;
     }
 
     protected override void OnKeyDown(KeyEventArgs e)
     {
+        if (!IsRenderingEnabled || vm is null)
+            return;
+
         if (e.PhysicalKey == PhysicalKey.Space)
         {
             TranslationMoveOnPressed();
         }
         else if (e.PhysicalKey == PhysicalKey.F)
         {
-            var roomItems = Updater.MakeRoomItems(vm!.Room);
+            var roomItems = Updater.MakeRoomItems(vm.Room);
             FocusOnSelectedItem(roomItems);
         }
     }
 
     protected override void OnKeyUp(KeyEventArgs e)
     {
+        if (!IsRenderingEnabled || vm is null)
+            return;
+
         if (e.PhysicalKey == PhysicalKey.Space)
         {
             TranslationMoveOnReleased();
@@ -236,22 +276,46 @@ public class UndertaleRoomEditor : Control
 
     public override void Render(DrawingContext context)
     {
-        if (IsEffectivelyVisible)
+        if (!IsEffectivelyVisible || vm is null)
+            return;
+
+        UndertaleRoomViewModel roomVM = vm;
+        scaling = roomVM.Zoom;
+
+        if (!IsRenderingEnabled)
         {
-            scaling = vm?.Zoom ?? 1;
-
-            context.Custom(new CustomDrawOperation(this));
-
-#if DEBUG
-            RenderDebugText(context);
-#endif
+            RenderPlaceholder(context);
+            return;
         }
 
-        TopLevel topLevel = TopLevel.GetTopLevel(this)!;
-        topLevel.RequestAnimationFrame(_ =>
+        context.Custom(new CustomDrawOperation(this, roomVM));
+
+#if DEBUG
+        RenderDebugText(context);
+#endif
+
+        TopLevel.GetTopLevel(this)?.RequestAnimationFrame(_ =>
         {
             InvalidateVisual();
         });
+    }
+
+    void RenderPlaceholder(DrawingContext context)
+    {
+        Rect rect = new(0, 0, Bounds.Width, Bounds.Height);
+        context.DrawRectangle(
+            new SolidColorBrush(Color.FromRgb(35, 39, 45)),
+            new Pen(new SolidColorBrush(Color.FromRgb(78, 86, 96))),
+            rect);
+
+        context.DrawText(new FormattedText(
+            "Room preview not rendered",
+            CultureInfo.CurrentCulture,
+            FlowDirection.LeftToRight,
+            Typeface.Default,
+            13,
+            new SolidColorBrush(Color.FromRgb(210, 216, 224))),
+            new Point(12, 12));
     }
 
     InteractionMode GetInteractionMode()
@@ -268,7 +332,7 @@ public class UndertaleRoomEditor : Control
 
     UndertaleRoom.Layer? GetSelectedTilesLayer()
     {
-        if (vm!.RoomTreeItemsSelectedItem is UndertaleRoom.Layer { LayerType: UndertaleRoom.LayerType.Tiles } tilesLayer)
+        if (vm?.RoomTreeItemsSelectedItem is UndertaleRoom.Layer { LayerType: UndertaleRoom.LayerType.Tiles } tilesLayer)
         {
             return tilesLayer;
         }
@@ -304,7 +368,10 @@ public class UndertaleRoomEditor : Control
             if (roomItem.Selectable is null)
                 continue;
 
-            if (vm!.IsSelectAnyLayerEnabled || vm!.CategorySelected is null || roomItem.Selectable.Category == vm!.CategorySelected)
+            if (vm is null ||
+                vm.IsSelectAnyLayerEnabled ||
+                vm.CategorySelected is null ||
+                roomItem.Selectable.Category == vm.CategorySelected)
                 if (RectContainsPoint(roomItem.Selectable.Bounds, roomItem.Selectable.Rotation, roomItem.Selectable.Pivot, pointerPositionInRoom))
                 {
                     hoveredItem = roomItem.Object;
@@ -322,14 +389,18 @@ public class UndertaleRoomEditor : Control
             RoomItemProperties properties = hoveredRoomItem.Selectable.GetProperties();
             itemMoveOffset = new(pointerPositionInRoom.X - properties.X, pointerPositionInRoom.Y - properties.Y);
 
-            vm!.RoomTreeItemsSelectedItem = hoveredRoomItem.Object;
+            if (vm is not null)
+                vm.RoomTreeItemsSelectedItem = hoveredRoomItem.Object;
         }
         else
         {
-            if (!vm!.IsSelectAnyLayerEnabled)
-                vm!.RoomTreeItemsSelectedItem = vm.FindItemFromCategory(vm!.CategorySelected);
+            if (vm is null)
+                return;
+
+            if (!vm.IsSelectAnyLayerEnabled)
+                vm.RoomTreeItemsSelectedItem = vm.FindItemFromCategory(vm.CategorySelected);
             else
-                vm!.RoomTreeItemsSelectedItem = null;
+                vm.RoomTreeItemsSelectedItem = null;
         }
     }
 
@@ -341,7 +412,7 @@ public class UndertaleRoomEditor : Control
             double x = pointerPositionInRoom.X - itemMoveOffset.X;
             double y = pointerPositionInRoom.Y - itemMoveOffset.Y;
 
-            if (vm!.IsGridEnabled)
+            if (vm?.IsGridEnabled == true)
             {
                 x = (Math.Floor(pointerPositionInRoom.X / vm.GridWidth) * vm.GridWidth)
                     - (Math.Floor(itemMoveOffset.X / vm.GridWidth) * vm.GridWidth);
@@ -460,7 +531,6 @@ public class UndertaleRoomEditor : Control
 
         readonly UndertaleRoomEditor editor;
 
-        readonly UndertaleRoomViewModel vm;
         readonly Vector translation;
         readonly double scaling;
 
@@ -481,12 +551,11 @@ public class UndertaleRoomEditor : Control
 
         readonly SKColor selectedColor;
 
-        public CustomDrawOperation(UndertaleRoomEditor editor)
+        public CustomDrawOperation(UndertaleRoomEditor editor, UndertaleRoomViewModel vm)
         {
             this.editor = editor;
             Bounds = new(0, 0, editor.Bounds.Width, editor.Bounds.Height);
 
-            vm = editor.vm!;
             translation = editor.translation;
             scaling = editor.scaling;
 
@@ -595,9 +664,8 @@ public class UndertaleRoomEditor : Control
                 stopWatch.Stop();
                 editor.customDrawOperationTime = Math.Ceiling(stopWatch.Elapsed.TotalMilliseconds);
             }
-            catch (Exception e)
+            catch
             {
-                Debugger.Break();
                 throw;
             }
         }

--- a/UndertaleModToolAvalonia/Controls/UndertaleRoomTilePicker.cs
+++ b/UndertaleModToolAvalonia/Controls/UndertaleRoomTilePicker.cs
@@ -124,8 +124,7 @@ public class UndertaleRoomTilePicker : Control
             });
         }
 
-        TopLevel topLevel = TopLevel.GetTopLevel(this)!;
-        topLevel.RequestAnimationFrame(_ =>
+        TopLevel.GetTopLevel(this)?.RequestAnimationFrame(_ =>
         {
             InvalidateVisual();
         });

--- a/UndertaleModToolAvalonia/Controls/UndertaleStringReferenceView.axaml.cs
+++ b/UndertaleModToolAvalonia/Controls/UndertaleStringReferenceView.axaml.cs
@@ -63,14 +63,14 @@ public partial class UndertaleStringReferenceView : UserControl
 
     public void Open()
     {
-        MainViewModel mainView = (this.FindLogicalAncestorOfType<MainView>()!.DataContext as MainViewModel)!;
-        mainView.TabOpen(Reference);
+        if (TryGetMainViewModel() is { } mainView)
+            mainView.TabOpen(Reference);
     }
 
     public void OpenInNewTab()
     {
-        MainViewModel mainView = (this.FindLogicalAncestorOfType<MainView>()!.DataContext as MainViewModel)!;
-        mainView.TabOpen(Reference, inNewTab: true);
+        if (TryGetMainViewModel() is { } mainView)
+            mainView.TabOpen(Reference, inNewTab: true);
     }
 
     void UpdateString(TextBox textBox)
@@ -78,7 +78,7 @@ public partial class UndertaleStringReferenceView : UserControl
         if (Reference is not null)
         {
             // TODO: Ask if user wants to change all references or just this one
-            BindingOperations.GetBindingExpressionBase(textBox, TextBox.TextProperty)!.UpdateSource();
+            BindingOperations.GetBindingExpressionBase(textBox, TextBox.TextProperty)?.UpdateSource();
         }
         else
         {
@@ -88,7 +88,14 @@ public partial class UndertaleStringReferenceView : UserControl
 
     void UpdateTextBoxWatermark()
     {
-        this.Find<TextBox>("TextBox")!.PlaceholderText = (Reference is null) ? "(UndertaleString reference)" : "";
+        TextBox? textBox = this.Find<TextBox>("TextBox");
+        if (textBox is not null)
+            textBox.PlaceholderText = (Reference is null) ? "(UndertaleString reference)" : "";
+    }
+
+    private MainViewModel? TryGetMainViewModel()
+    {
+        return this.FindLogicalAncestorOfType<MainView>()?.DataContext as MainViewModel;
     }
 }
 

--- a/UndertaleModToolAvalonia/Core/AudioMetadata.cs
+++ b/UndertaleModToolAvalonia/Core/AudioMetadata.cs
@@ -1,0 +1,69 @@
+using System.Globalization;
+using UndertaleModLib;
+using UndertaleModLib.Models;
+
+namespace UndertaleModToolAvalonia;
+
+public static class AudioMetadata
+{
+    public static string DescribeFormat(byte[]? data)
+    {
+        data ??= [];
+
+        if (data.Length == 0)
+            return "Empty";
+
+        if (HasAscii(data, 0, "RIFF") && HasAscii(data, 8, "WAVE"))
+            return "WAV";
+
+        if (HasAscii(data, 0, "OggS"))
+            return "Ogg";
+
+        if (HasAscii(data, 0, "fLaC"))
+            return "FLAC";
+
+        if (HasAscii(data, 0, "ID3") || IsMp3Frame(data))
+            return "MP3";
+
+        if (HasAscii(data, 0, "FORM") && HasAscii(data, 8, "AIFF"))
+            return "AIFF";
+
+        return "Unknown";
+    }
+
+    public static string FormatByteCount(int count)
+    {
+        return $"{count.ToString("N0", CultureInfo.InvariantCulture)} bytes";
+    }
+
+    public static string DescribeEmbeddedAudio(UndertaleEmbeddedAudio? audio, UndertaleData? data)
+    {
+        if (audio is null)
+            return "No embedded audio linked.";
+
+        int index = data?.EmbeddedAudio?.IndexOf(audio) ?? -1;
+        string idText = index >= 0 ? $"Embedded audio #{index}" : "Embedded audio";
+        byte[] audioData = audio.Data ?? [];
+
+        return $"{idText}; {DescribeFormat(audioData)}; {FormatByteCount(audioData.Length)}.";
+    }
+
+    static bool HasAscii(byte[] data, int offset, string value)
+    {
+        if (offset < 0 || data.Length < offset + value.Length)
+            return false;
+
+        for (int i = 0; i < value.Length; i++)
+        {
+            if (data[offset + i] != (byte)value[i])
+                return false;
+        }
+
+        return true;
+    }
+
+    static bool IsMp3Frame(byte[] data)
+    {
+        return data.Length >= 2 && data[0] == 0xff && (data[1] & 0xe0) == 0xe0;
+    }
+}

--- a/UndertaleModToolAvalonia/Core/AudioPlayer.cs
+++ b/UndertaleModToolAvalonia/Core/AudioPlayer.cs
@@ -7,9 +7,10 @@ namespace UndertaleModToolAvalonia;
 
 public class AudioPlayer : IDisposable
 {
-    static Action<Action> mainThreadAction = null!;
+    static Action<Action> mainThreadAction = action => action();
 
     static IntPtr mixer = IntPtr.Zero;
+    static bool mixerInitialized;
 
     IntPtr audio;
     IntPtr track;
@@ -19,43 +20,61 @@ public class AudioPlayer : IDisposable
 
     public AudioPlayer(byte[] data)
     {
+        if (data.Length == 0)
+            throw new ArgumentException("No audio data was provided.", nameof(data));
+
+        EnsureInitialized();
+
         // Don't allow this be deallocated until the sound stops.
         trackStoppedCallback = new(OnTrackStoppped);
         trackStoppedCallbackHandle = GCHandle.Alloc(trackStoppedCallback);
 
-        // Load audio
-        GCHandle dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
-
-        IntPtr io = SDL.IOFromConstMem(dataHandle.AddrOfPinnedObject(), (nuint)data.Length);
-        if (io == IntPtr.Zero)
-            throw new InvalidOperationException($"{SDL.GetError()}");
-
-        audio = Mixer.LoadAudioIO(mixer, io, predecode: true, closeio: true);
-
-        dataHandle.Free();
-
-        if (audio == IntPtr.Zero)
+        GCHandle dataHandle = default;
+        try
         {
-            // TODO: Show some kind of error
-            return;
+            // Load audio
+            dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
+
+            IntPtr io = SDL.IOFromConstMem(dataHandle.AddrOfPinnedObject(), (nuint)data.Length);
+            if (io == IntPtr.Zero)
+                throw new InvalidOperationException($"{SDL.GetError()}");
+
+            audio = Mixer.LoadAudioIO(mixer, io, predecode: true, closeio: true);
+            if (audio == IntPtr.Zero)
+                throw new InvalidOperationException($"{SDL.GetError()}");
+
+            // Create track and play
+            track = Mixer.CreateTrack(mixer);
+            if (track == IntPtr.Zero)
+                throw new InvalidOperationException($"{SDL.GetError()}");
+
+            if (!Mixer.SetTrackAudio(track, audio))
+                throw new InvalidOperationException($"{SDL.GetError()}");
+
+            if (!Mixer.PlayTrack(track, 0))
+                throw new InvalidOperationException($"{SDL.GetError()}");
+
+            if (!Mixer.SetTrackStoppedCallback(track, trackStoppedCallback, IntPtr.Zero))
+                throw new InvalidOperationException($"{SDL.GetError()}");
         }
-
-        // Create track and play
-        track = Mixer.CreateTrack(mixer);
-        if (track == IntPtr.Zero)
-            throw new InvalidOperationException($"{SDL.GetError()}");
-
-        if (!Mixer.SetTrackAudio(track, audio))
-            throw new InvalidOperationException($"{SDL.GetError()}");
-
-        if (!Mixer.PlayTrack(track, 0))
-            throw new InvalidOperationException($"{SDL.GetError()}");
-
-        if (!Mixer.SetTrackStoppedCallback(track, trackStoppedCallback, IntPtr.Zero))
-            throw new InvalidOperationException($"{SDL.GetError()}");
+        catch
+        {
+            Dispose();
+            throw;
+        }
+        finally
+        {
+            if (dataHandle.IsAllocated)
+                dataHandle.Free();
+        }
     }
 
-    public static void Init(Action<Action> _mainThreadAction)
+    public static void Configure(Action<Action> _mainThreadAction)
+    {
+        mainThreadAction = _mainThreadAction;
+    }
+
+    static void EnsureInitialized()
     {
         if ((SDL.WasInit(SDL.InitFlags.Audio) & SDL.InitFlags.Audio) == 0)
         {
@@ -64,8 +83,14 @@ public class AudioPlayer : IDisposable
             if (!SDL.Init(SDL.InitFlags.Audio))
                 throw new InvalidOperationException($"{SDL.GetError()}");
 
+        }
+
+        if (!mixerInitialized)
+        {
             if (!Mixer.Init())
                 throw new InvalidOperationException($"{SDL.GetError()}");
+
+            mixerInitialized = true;
         }
 
         if (mixer == IntPtr.Zero)
@@ -74,8 +99,6 @@ public class AudioPlayer : IDisposable
             if (mixer == IntPtr.Zero)
                 throw new InvalidOperationException($"{SDL.GetError()}");
         }
-
-        mainThreadAction = _mainThreadAction;
     }
 
     public void Stop()

--- a/UndertaleModToolAvalonia/Core/IView.cs
+++ b/UndertaleModToolAvalonia/Core/IView.cs
@@ -15,43 +15,43 @@ public interface IView
 
     public async Task<IReadOnlyList<IStorageFile>> OpenFileDialog(FilePickerOpenOptions options)
     {
-        TopLevel topLevel = TopLevel.GetTopLevel(View)!;
+        TopLevel topLevel = View.RequireTopLevel(nameof(OpenFileDialog));
         return await topLevel.StorageProvider.OpenFilePickerAsync(options);
     }
 
     public async Task<IStorageFile?> SaveFileDialog(FilePickerSaveOptions options)
     {
-        TopLevel topLevel = TopLevel.GetTopLevel(View)!;
+        TopLevel topLevel = View.RequireTopLevel(nameof(SaveFileDialog));
         return await topLevel.StorageProvider.SaveFilePickerAsync(options);
     }
 
     public async Task<IReadOnlyList<IStorageFolder>> OpenFolderDialog(FolderPickerOpenOptions options)
     {
-        TopLevel topLevel = TopLevel.GetTopLevel(View)!;
+        TopLevel topLevel = View.RequireTopLevel(nameof(OpenFolderDialog));
         return await topLevel.StorageProvider.OpenFolderPickerAsync(options);
     }
 
     public async Task<bool> LaunchUriAsync(Uri uri)
     {
-        TopLevel topLevel = TopLevel.GetTopLevel(View)!;
+        TopLevel topLevel = View.RequireTopLevel(nameof(LaunchUriAsync));
         return await topLevel.Launcher.LaunchUriAsync(uri);
     }
 
     public async Task<MessageWindow.Result> MessageDialog(string message, string? title = null, MessageWindow.Buttons buttons = MessageWindow.Buttons.OK)
     {
-        Window window = View.FindLogicalAncestorOfType<Window>() ?? throw new InvalidOperationException();
+        Window window = View.RequireWindow(nameof(MessageDialog));
         return await new MessageWindow(message, title, buttons).ShowDialog<MessageWindow.Result>(window);
     }
 
     public async Task<string?> TextBoxDialog(string message, string text = "", string? title = null, bool isMultiline = false, bool isReadOnly = false)
     {
-        Window window = View.FindLogicalAncestorOfType<Window>() ?? throw new InvalidOperationException();
+        Window window = View.RequireWindow(nameof(TextBoxDialog));
         return await new TextBoxWindow(message, text, title, isMultiline, isReadOnly).ShowDialog<string?>(window);
     }
 
     public ILoaderWindow LoaderOpen()
     {
-        Window window = View.FindLogicalAncestorOfType<Window>(true) ?? throw new InvalidOperationException();
+        Window window = View.RequireWindow(nameof(LoaderOpen), true);
         LoaderWindow loaderWindow = new();
         loaderWindow.ShowDelayed(window);
         return loaderWindow;
@@ -59,7 +59,22 @@ public interface IView
 
     public IInputElement? GetFocusedElement()
     {
-        TopLevel topLevel = TopLevel.GetTopLevel(View)!;
+        TopLevel topLevel = View.RequireTopLevel(nameof(GetFocusedElement));
         return topLevel.FocusManager?.GetFocusedElement();
+    }
+}
+
+internal static class ViewGuardExtensions
+{
+    public static TopLevel RequireTopLevel(this Control view, string operation)
+    {
+        return TopLevel.GetTopLevel(view)
+            ?? throw new InvalidOperationException($"{operation} requires the view to be attached to a top-level window.");
+    }
+
+    public static Window RequireWindow(this Control view, string operation, bool includeSelf = false)
+    {
+        return view.FindLogicalAncestorOfType<Window>(includeSelf)
+            ?? throw new InvalidOperationException($"{operation} requires the view to be attached to a window.");
     }
 }

--- a/UndertaleModToolAvalonia/Core/ImportExport.cs
+++ b/UndertaleModToolAvalonia/Core/ImportExport.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using ImageMagick;
 using SkiaSharp;
 using UndertaleModLib.Models;
 using UndertaleModLib.Util;
@@ -11,21 +12,17 @@ public static class ImportExport
 {
     public static async Task ImportEmbeddedAudio(UndertaleEmbeddedAudio embeddedAudio, Stream stream)
     {
-        byte[] bytes = new byte[stream.Length];
-        await stream.ReadExactlyAsync(bytes);
-
-        embeddedAudio.Data = bytes;
+        embeddedAudio.Data = await ReadAllBytesAsync(stream);
     }
 
     public static async Task ExportEmbeddedAudio(UndertaleEmbeddedAudio embeddedAudio, Stream stream)
     {
-        await stream.WriteAsync(embeddedAudio.Data);
+        await stream.WriteAsync(embeddedAudio.Data ?? []);
     }
 
     public static async Task ImportEmbeddedTexture(UndertaleEmbeddedTexture embeddedTexture, Stream stream)
     {
-        byte[] bytes = new byte[stream.Length];
-        await stream.ReadExactlyAsync(bytes);
+        byte[] bytes = await ReadAllBytesAsync(stream);
 
         GMImage gmImage = GMImage.FromPng(bytes, verifyHeader: true);
         gmImage.ConvertToFormat(embeddedTexture.TextureData.Image.Format);
@@ -40,12 +37,29 @@ public static class ImportExport
         await stream.WriteAsync(embeddedTexture.TextureData.Image.GetData());
     }
 
-    public static async Task ExportEmbeddedTextureAsPNG(UndertaleEmbeddedTexture embeddedTexture, Stream stream)
+    public static Task ExportEmbeddedTextureAsPNG(UndertaleEmbeddedTexture embeddedTexture, Stream stream)
     {
         embeddedTexture.TextureData.Image.SavePng(stream);
+        return Task.CompletedTask;
     }
 
-    public static async Task ExportRoomAsPNG(UndertaleRoom room, Stream stream)
+    public static Task ImportTexturePageItemAsPNG(UndertaleTexturePageItem texturePageItem, Stream stream)
+    {
+        MagickReadSettings settings = new()
+        {
+            ColorSpace = ColorSpace.sRGB,
+        };
+        using MagickImage image = new(stream, settings);
+        image.Alpha(AlphaOption.Set);
+        image.Format = MagickFormat.Bgra;
+        image.Depth = 8;
+        image.SetCompression(CompressionMethod.NoCompression);
+
+        texturePageItem.ReplaceTexture(image);
+        return Task.CompletedTask;
+    }
+
+    public static Task ExportRoomAsPNG(UndertaleRoom room, Stream stream)
     {
         // NOTE: This is a CPU bitmap, unlike the GPU surface used when rendering in the UI.
         SKBitmap bitmap = new((int)room.Width, (int)room.Height, SKColorType.Bgra8888, SKAlphaType.Unpremul);
@@ -56,13 +70,14 @@ public static class ImportExport
 
         bool result = bitmap.Encode(stream, SKEncodedImageFormat.Png, 100);
         if (!result)
-            throw new InvalidOperationException();
+            throw new InvalidOperationException("Failed to encode room preview as PNG.");
+
+        return Task.CompletedTask;
     }
 
     public static async Task ImportSpriteCollisionMaskData(UndertaleSprite sprite, int collisionMaskIndex, Stream stream, MainViewModel mainVM)
     {
-        byte[] bytes = new byte[stream.Length];
-        await stream.ReadExactlyAsync(bytes);
+        byte[] bytes = await ReadAllBytesAsync(stream);
 
         (int width, int height) = sprite.CalculateMaskDimensions(mainVM.Data);
         UndertaleSprite.MaskEntry maskEntry = new(bytes, width, height);
@@ -75,7 +90,7 @@ public static class ImportExport
         await stream.WriteAsync(sprite.CollisionMasks[collisionMaskIndex].Data);
     }
 
-    public static async Task ExportTexturePageItemAsPNG(UndertaleTexturePageItem texturePageItem, Stream stream, MainViewModel mainVM)
+    public static Task ExportTexturePageItemAsPNG(UndertaleTexturePageItem texturePageItem, Stream stream, MainViewModel mainVM)
     {
         SKBitmap bitmap = new(texturePageItem.BoundingWidth, texturePageItem.BoundingHeight, SKColorType.Bgra8888, SKAlphaType.Unpremul);
         SKCanvas canvas = new(bitmap);
@@ -83,12 +98,24 @@ public static class ImportExport
         SKImage? image = mainVM.ImageCache.GetCachedImageFromTexturePageItem(texturePageItem);
 
         if (image is null)
-            throw new InvalidOperationException();
+            throw new InvalidOperationException("Texture page item image is not available in the cache.");
 
         canvas.DrawImage(image, SKRect.Create(texturePageItem.TargetX, texturePageItem.TargetY, texturePageItem.TargetWidth, texturePageItem.TargetHeight));
 
         bool result = bitmap.Encode(stream, SKEncodedImageFormat.Png, 100);
         if (!result)
-            throw new InvalidOperationException();
+            throw new InvalidOperationException("Failed to encode texture page item as PNG.");
+
+        return Task.CompletedTask;
+    }
+
+    private static async Task<byte[]> ReadAllBytesAsync(Stream stream)
+    {
+        if (stream is MemoryStream memoryStream && memoryStream.TryGetBuffer(out ArraySegment<byte> buffer))
+            return buffer.ToArray();
+
+        using MemoryStream output = new();
+        await stream.CopyToAsync(output);
+        return output.ToArray();
     }
 }

--- a/UndertaleModToolAvalonia/Core/ObservableCollectionView.cs
+++ b/UndertaleModToolAvalonia/Core/ObservableCollectionView.cs
@@ -161,7 +161,11 @@ public class ObservableCollectionView<TInput, TOutput>
 
     private void OnInputAdd(NotifyCollectionChangedEventArgs e)
     {
-        TInput item = (TInput)e.NewItems![0]!;
+        if (!TryGetNewItem(e, out TInput item) || e.NewStartingIndex < 0)
+        {
+            OnInputReset();
+            return;
+        }
 
         // Find where in output to insert
         int i = outputIndexToInputIndexMap.BinarySearch(e.NewStartingIndex);
@@ -186,6 +190,12 @@ public class ObservableCollectionView<TInput, TOutput>
 
     private void OnInputRemove(NotifyCollectionChangedEventArgs e)
     {
+        if (e.OldStartingIndex < 0)
+        {
+            OnInputReset();
+            return;
+        }
+
         // Find where in output to remove
         int i = outputIndexToInputIndexMap.BinarySearch(e.OldStartingIndex);
         if (i >= 0)
@@ -209,7 +219,12 @@ public class ObservableCollectionView<TInput, TOutput>
 
     private void OnInputReplace(NotifyCollectionChangedEventArgs e)
     {
-        TInput item = (TInput)e.NewItems![0]!;
+        if (!TryGetNewItem(e, out TInput item) || e.OldStartingIndex < 0)
+        {
+            OnInputReset();
+            return;
+        }
+
         bool passes = DoesPassFilter(item);
 
         // Find where item is in output
@@ -242,6 +257,12 @@ public class ObservableCollectionView<TInput, TOutput>
 
     private void OnInputMove(NotifyCollectionChangedEventArgs e)
     {
+        if (!TryGetNewItem(e, out _) || e.OldStartingIndex < 0 || e.NewStartingIndex < 0)
+        {
+            OnInputReset();
+            return;
+        }
+
         // TODO: Actually call Move().
         OnInputRemove(e);
         OnInputAdd(e);
@@ -316,6 +337,31 @@ public class ObservableCollectionView<TInput, TOutput>
     }
 
     private bool DoesPassFilter(TInput item) => filterPredicate is null || filterPredicate(item);
+
+    private static bool TryGetNewItem(NotifyCollectionChangedEventArgs e, out TInput item)
+    {
+        if (e.NewItems is not { Count: > 0 } newItems)
+        {
+            item = default!;
+            return false;
+        }
+
+        object? rawItem = newItems[0];
+        if (rawItem is null)
+        {
+            item = default!;
+            return default(TInput) is null;
+        }
+
+        if (rawItem is TInput typedItem)
+        {
+            item = typedItem;
+            return true;
+        }
+
+        item = default!;
+        return false;
+    }
 
     private TOutput TransformItem(TInput item)
     {

--- a/UndertaleModToolAvalonia/Core/Scripting.cs
+++ b/UndertaleModToolAvalonia/Core/Scripting.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -18,12 +19,18 @@ using UndertaleModLib.Decompiler;
 using UndertaleModLib.Models;
 using UndertaleModLib.Project;
 using UndertaleModLib.Scripting;
+using UndertaleModLib.Util;
 
 namespace UndertaleModToolAvalonia;
 
 public class Scripting
 {
     public readonly MainViewModel MainVM;
+
+    public bool ScriptExecutionSuccess { get; private set; } = true;
+    public string ScriptErrorMessage { get; private set; } = "";
+    public string ScriptErrorType { get; private set; } = "";
+    public bool FinishedMessageEnabled { get; private set; } = true;
 
     public Scripting(IServiceProvider serviceProvider)
     {
@@ -34,29 +41,11 @@ public class Scripting
     {
         try
         {
+            SetScriptSuccess();
+            FinishedMessageEnabled = true;
             MainVM.IsEnabled = false;
 
-            Script<object?> script = CSharpScript.Create(text, ScriptOptions.Default
-                .AddImports(
-                    "System",
-                    "System.Collections.Generic",
-                    "System.Linq",
-                    "System.IO",
-                    "System.Text",
-                    "System.Text.RegularExpressions",
-                    "System.Threading.Tasks",
-                    "UndertaleModLib",
-                    "UndertaleModLib.Compiler",
-                    "UndertaleModLib.Decompiler",
-                    "UndertaleModLib.Models",
-                    "UndertaleModLib.Scripting")
-                .AddReferences(
-                    "System.Core",
-                    "UndertaleModLib")
-                .WithFilePath(filePath)
-                .WithFileEncoding(Encoding.Default)
-                .WithEmitDebugInformation(true),
-                typeof(IScriptInterface));
+            Script<object?> script = CreateScript(text, filePath);
 
             ImmutableArray<Diagnostic> diagnostics = await Task.Run(() => script.Compile());
 
@@ -64,7 +53,8 @@ public class Scripting
             if (errors.Any())
             {
                 string message = String.Join("\n", errors);
-                await MainVM.View!.MessageDialog(message, title: "Script compilation error");
+                SetScriptError("CompilationErrorException", message);
+                await ShowScriptDialog(message, "Script compilation error");
 
                 return null;
             }
@@ -78,11 +68,15 @@ public class Scripting
             }
             catch (ScriptException e)
             {
-                await MainVM.View!.MessageDialog(e.Message, title: "Error from script");
+                string message = e.Message;
+                SetScriptError(e.GetType().Name, message);
+                await ShowScriptDialog(message, "Error from script");
             }
             catch (Exception e)
             {
-                await MainVM.View!.MessageDialog(e.ToString(), title: "Script execution error");
+                string message = ScriptingUtil.PrettifyException(in e);
+                SetScriptError(e.GetType().Name, message);
+                await ShowScriptDialog(message, "Script execution error");
             }
             finally
             {
@@ -96,24 +90,137 @@ public class Scripting
 
         return null;
     }
+
+    internal Script<object?> CreateScript(string text, string? filePath = null)
+    {
+        return CSharpScript.Create(text, ScriptingUtil.CreateDefaultScriptOptions()
+            .AddImports(
+                "System.Linq",
+                "System.Text",
+                "System.Threading.Tasks")
+            .WithFilePath(filePath)
+            .WithFileEncoding(filePath is null ? Encoding.Default : Encoding.UTF8)
+            .WithEmitDebugInformation(true),
+            typeof(IScriptInterface));
+    }
+
+    internal bool LintScript(string text, string? filePath, out string message)
+    {
+        ImmutableArray<Diagnostic> diagnostics = CreateScript(text, filePath).Compile();
+        Diagnostic[] errors = diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
+        if (errors.Length == 0)
+        {
+            SetScriptSuccess();
+            message = "";
+            return true;
+        }
+
+        message = String.Join("\n", errors.Select(error => error.ToString()));
+        SetScriptError("CompilationErrorException", message);
+        return false;
+    }
+
+    internal void SetScriptSuccess()
+    {
+        ScriptExecutionSuccess = true;
+        ScriptErrorMessage = "";
+        ScriptErrorType = "";
+    }
+
+    internal void SetScriptError(string type, string message)
+    {
+        ScriptExecutionSuccess = false;
+        ScriptErrorMessage = message;
+        ScriptErrorType = type;
+    }
+
+    internal void SetFinishedMessage(bool isEnabled)
+    {
+        FinishedMessageEnabled = isEnabled;
+    }
+
+    public bool ConsumeFinishedMessageEnabled()
+    {
+        bool result = FinishedMessageEnabled;
+        FinishedMessageEnabled = true;
+        return result;
+    }
+
+    private async Task ShowScriptDialog(string message, string title)
+    {
+        if (MainVM.View is not null)
+            await MainVM.View.MessageDialog(message, title: title);
+    }
+
+    internal static IReadOnlyList<FilePickerFileType> CreateFilePickerTypes(string? filter, IReadOnlyList<FilePickerFileType>? fallback = null)
+    {
+        if (String.IsNullOrWhiteSpace(filter))
+            return fallback ?? FilePickerFileTypes.All;
+
+        string[] parts = filter.Split('|', StringSplitOptions.TrimEntries);
+        if (parts.Length < 2)
+            return fallback ?? FilePickerFileTypes.All;
+
+        List<FilePickerFileType> fileTypes = [];
+        for (int i = 0; i + 1 < parts.Length; i += 2)
+        {
+            string name = String.IsNullOrWhiteSpace(parts[i]) ? "Files" : parts[i];
+            List<string> patterns = parts[i + 1]
+                .Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+                .Select(NormalizeFilterPattern)
+                .Where(pattern => !String.IsNullOrWhiteSpace(pattern))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (patterns.Count == 0)
+                continue;
+
+            fileTypes.Add(new FilePickerFileType(name)
+            {
+                Patterns = patterns,
+            });
+        }
+
+        return fileTypes.Count > 0 ? fileTypes : fallback ?? FilePickerFileTypes.All;
+    }
+
+    private static string NormalizeFilterPattern(string pattern)
+    {
+        if (pattern == "*")
+            return "*.*";
+
+        if (pattern.StartsWith("*.") || pattern.StartsWith('*'))
+            return pattern;
+
+        string trimmed = pattern.TrimStart('.');
+        return $"*.{trimmed}";
+    }
 }
 
 public class ScriptGlobals : IScriptInterface, IDisposable
 {
+    private readonly Scripting scripting;
     private readonly MainViewModel mainVM;
     private readonly string? scriptPath;
 
     private ILoaderWindow? loaderWindow;
     private int loaderValue;
+    private CancellationTokenSource? progressUpdaterCts;
+    private Task? progressUpdater;
 
     public ScriptGlobals(Scripting scripting, string? scriptPath)
     {
+        this.scripting = scripting;
         mainVM = scripting.MainVM;
         this.scriptPath = scriptPath;
     }
 
     public void Dispose()
     {
+        progressUpdaterCts?.Cancel();
+        progressUpdaterCts?.Dispose();
+        progressUpdaterCts = null;
+        progressUpdater = null;
         loaderWindow?.Close();
         loaderWindow = null;
     }
@@ -126,21 +233,23 @@ public class ScriptGlobals : IScriptInterface, IDisposable
 
     public string? ScriptPath => scriptPath;
 
-    public object Highlighted => throw new NotImplementedException();
+    public object? Highlighted => Selected;
 
-    public object Selected => throw new NotImplementedException();
+    public object? Selected => mainVM.TabSelected?.Content is IUndertaleResourceViewModel resourceViewModel
+        ? resourceViewModel.Resource
+        : mainVM.TabSelected?.Content;
 
-    public bool CanSave => throw new NotImplementedException();
+    public bool CanSave => mainVM.Data is not null;
 
-    public bool ScriptExecutionSuccess => throw new NotImplementedException();
+    public bool ScriptExecutionSuccess => scripting.ScriptExecutionSuccess;
 
-    public string ScriptErrorMessage => throw new NotImplementedException();
+    public string ScriptErrorMessage => scripting.ScriptErrorMessage;
 
     public string? ExePath => Path.GetDirectoryName(Environment.ProcessPath);
 
-    public string ScriptErrorType => throw new NotImplementedException();
+    public string ScriptErrorType => scripting.ScriptErrorType;
 
-    public bool IsAppClosed => throw new NotImplementedException();
+    public bool IsAppClosed => false;
 
     public Action<Action> MainThreadAction => Dispatcher.UIThread.Invoke;
 
@@ -158,25 +267,28 @@ public class ScriptGlobals : IScriptInterface, IDisposable
     {
         Interlocked.Add(ref loaderValue, amount);
 
-        Dispatcher.UIThread.Post(() =>
+        if (progressUpdaterCts is null)
         {
-            loaderWindow?.SetValue(loaderValue);
-        }, DispatcherPriority.Background);
+            Dispatcher.UIThread.Post(() =>
+            {
+                loaderWindow?.SetValue(loaderValue);
+            }, DispatcherPriority.Background);
+        }
     }
 
     public void ChangeSelection(object newSelection, bool inNewTab = false)
     {
-        // TODO: Implement
+        Dispatcher.UIThread.Invoke(() => mainVM.TabOpen(newSelection, inNewTab));
     }
 
     public Task ClickableSearchOutput(string title, string query, int resultsCount, IOrderedEnumerable<KeyValuePair<string, List<(int lineNum, string codeLine)>>> resultsDict, bool showInDecompiledView, IOrderedEnumerable<string>? failedList = null)
     {
-        throw new NotImplementedException();
+        return ShowSearchOutput(title, query, resultsCount, resultsDict, failedList);
     }
 
     public Task ClickableSearchOutput(string title, string query, int resultsCount, IDictionary<string, List<(int lineNum, string codeLine)>> resultsDict, bool showInDecompiledView, IEnumerable<string>? failedList = null)
     {
-        throw new NotImplementedException();
+        return ShowSearchOutput(title, query, resultsCount, resultsDict, failedList);
     }
 
     public void EnableUI()
@@ -232,48 +344,73 @@ public class ScriptGlobals : IScriptInterface, IDisposable
     {
         Interlocked.Increment(ref loaderValue);
 
-        Dispatcher.UIThread.Post(() =>
+        if (progressUpdaterCts is null)
         {
-            loaderWindow?.SetValue(loaderValue);
-        }, DispatcherPriority.Background);
+            Dispatcher.UIThread.Post(() =>
+            {
+                loaderWindow?.SetValue(loaderValue);
+            }, DispatcherPriority.Background);
+        }
     }
 
     public void InitializeScriptDialog()
     {
-        // TODO: Implement
+        SetProgressBar();
     }
 
     public bool LintUMTScript(string path)
     {
-        throw new NotImplementedException();
+        if (!File.Exists(path))
+        {
+            string message = $"{path} does not exist!";
+            scripting.SetScriptError("FileNotFoundException", message);
+            ScriptError(message);
+            return false;
+        }
+
+        string scriptText = File.ReadAllText(path, Encoding.UTF8);
+        if (scripting.LintScript(scriptText, path, out string errorMessage))
+            return true;
+
+        ScriptError(errorMessage, "Script compile error");
+        return false;
     }
 
     public bool MakeNewDataFile()
     {
-        return mainVM.NewData().Result;
+        return RunOnMainThread(() => mainVM.NewData());
     }
 
     public string? PromptChooseDirectory()
     {
-        IReadOnlyList<IStorageFolder> folders = Task.Run(() => mainVM.View!.OpenFolderDialog(new()
+        if (mainVM.View is not { } view)
+            return null;
+
+        IReadOnlyList<IStorageFolder> folders = RunOnMainThread(() => view.OpenFolderDialog(new()
         {
             Title = "Select directory",
-        })).Result;
+        }));
 
         if (folders.Count != 1)
             return null;
 
-        return folders[0].TryGetLocalPath();
+        string? path = folders[0].TryGetLocalPath();
+        if (path is null)
+            return null;
+
+        return Path.EndsInDirectorySeparator(path) ? path : path + Path.DirectorySeparatorChar;
     }
 
     public string? PromptLoadFile(string? defaultExt, string? filter)
     {
-        // TODO: filter
-        var files = Task.Run(() => mainVM.View!.OpenFileDialog(new FilePickerOpenOptions()
+        if (mainVM.View is not { } view)
+            return null;
+
+        var files = RunOnMainThread(() => view.OpenFileDialog(new FilePickerOpenOptions()
         {
             Title = "Load file",
-            FileTypeFilter = FilePickerFileTypes.All,
-        })).Result;
+            FileTypeFilter = Scripting.CreateFilePickerTypes(filter, FilePickerFileTypes.Data),
+        }));
 
         if (files.Count != 1)
             return null;
@@ -283,13 +420,15 @@ public class ScriptGlobals : IScriptInterface, IDisposable
 
     public string? PromptSaveFile(string defaultExt, string filter)
     {
-        // TODO: filter
-        var file = Task.Run(() => mainVM.View!.SaveFileDialog(new FilePickerSaveOptions()
+        if (mainVM.View is not { } view)
+            return null;
+
+        var file = RunOnMainThread(() => view.SaveFileDialog(new FilePickerSaveOptions()
         {
             Title = "Save file",
-            FileTypeChoices = FilePickerFileTypes.All,
+            FileTypeChoices = Scripting.CreateFilePickerTypes(filter, FilePickerFileTypes.Data),
             DefaultExtension = defaultExt,
-        })).Result;
+        }));
 
         if (file is null)
             return null;
@@ -299,48 +438,68 @@ public class ScriptGlobals : IScriptInterface, IDisposable
 
     public bool RunUMTScript(string path)
     {
-        throw new NotImplementedException();
+        if (!File.Exists(path))
+        {
+            string message = $"{path} does not exist!";
+            scripting.SetScriptError("FileNotFoundException", message);
+            ScriptError(message);
+            return false;
+        }
+
+        string scriptText = $"#line 1 \"{path}\"\n" + File.ReadAllText(path, Encoding.UTF8);
+        RunOnMainThread(() => scripting.RunScript(scriptText, path));
+        return scripting.ScriptExecutionSuccess;
     }
 
     public void ScriptError(string error, string title = "Error", bool SetConsoleText = true)
     {
-        mainVM.View!.MessageDialog(error, title).WaitOnDispatcherFrame();
+        ShowMessageDialogIfPossible(error, title);
 
         if (SetConsoleText)
         {
-            mainVM.CommandTextBoxText = error;
+            SetUMTConsoleText(error);
+            SetFinishedMessage(false);
         }
     }
 
     public string? ScriptInputDialog(string title, string label, string defaultInput, string cancelText, string submitText, bool isMultiline, bool preventClose)
     {
         // TODO: cancelText, submitText, preventClose
-        return mainVM.View!.TextBoxDialog(label, defaultInput, title: title, isMultiline: isMultiline).WaitOnDispatcherFrame();
+        if (mainVM.View is not { } view)
+            return null;
+
+        return RunOnMainThread(() => view.TextBoxDialog(label, defaultInput, title: title, isMultiline: isMultiline));
     }
 
     public void ScriptMessage(string message)
     {
-        mainVM.View!.MessageDialog(message, title: "Script message").WaitOnDispatcherFrame();
+        ShowMessageDialogIfPossible(message, "Script message");
     }
 
     public void ScriptOpenURL(string url)
     {
-        mainVM.View!.LaunchUriAsync(new(url)).Wait();
+        if (mainVM.View is not { } view)
+            return;
+
+        RunOnMainThread(() => view.LaunchUriAsync(new(url)));
     }
 
     public bool ScriptQuestion(string message)
     {
-        return mainVM.View!.MessageDialog(message, "Script question", MessageWindow.Buttons.YesNo).WaitOnDispatcherFrame() == MessageWindow.Result.Yes;
+        if (mainVM.View is not { } view)
+            return false;
+
+        return RunOnMainThread(() => view.MessageDialog(message, "Script question", MessageWindow.Buttons.YesNo)) == MessageWindow.Result.Yes;
     }
 
     public void ScriptWarning(string message)
     {
-        mainVM.View!.MessageDialog(message, title: "Script warning").WaitOnDispatcherFrame();
+        ShowMessageDialogIfPossible(message, "Script warning");
     }
 
     public void SetFinishedMessage(bool isFinishedMessageEnabled)
     {
-        // TODO: Implement
+        scripting.SetFinishedMessage(isFinishedMessageEnabled);
     }
 
     public void SetProgress(int value)
@@ -355,11 +514,14 @@ public class ScriptGlobals : IScriptInterface, IDisposable
 
     public void SetProgressBar(string message, string status, double progressValue, double maxValue)
     {
+        if (mainVM.View is not { } view)
+            return;
+
         loaderValue = (int)progressValue;
 
         Dispatcher.UIThread.Invoke(() =>
         {
-            loaderWindow ??= mainVM.View!.LoaderOpen();
+            loaderWindow ??= view.LoaderOpen();
             loaderWindow.EnsureShown();
             loaderWindow.SetMessage(message);
             loaderWindow.SetStatus(status);
@@ -370,38 +532,71 @@ public class ScriptGlobals : IScriptInterface, IDisposable
 
     public void SetProgressBar()
     {
+        if (mainVM.View is not { } view)
+            return;
+
         Dispatcher.UIThread.Invoke(() =>
         {
-            loaderWindow ??= mainVM.View!.LoaderOpen();
+            loaderWindow ??= view.LoaderOpen();
             loaderWindow.EnsureShown();
         });
     }
 
     public void SetUMTConsoleText(string message)
     {
-        mainVM.CommandTextBoxText = message;
+        RunOnMainThread(() => mainVM.CommandTextBoxText = message);
     }
 
     public string? SimpleTextInput(string title, string label, string defaultValue, bool allowMultiline, bool showDialog = true)
     {
         // TODO: showDialog
-        return mainVM.View!.TextBoxDialog(label, defaultValue, title: title, isMultiline: allowMultiline).WaitOnDispatcherFrame();
+        if (mainVM.View is not { } view)
+            return null;
+
+        return RunOnMainThread(() => view.TextBoxDialog(label, defaultValue, title: title, isMultiline: allowMultiline));
     }
 
     public void SimpleTextOutput(string title, string label, string message, bool allowMultiline)
     {
-        mainVM.View!.TextBoxDialog(label, message, title: title, isMultiline: allowMultiline, isReadOnly: true).WaitOnDispatcherFrame();
+        if (mainVM.View is not { } view)
+            return;
+
+        RunOnMainThread(() => view.TextBoxDialog(label, message, title: title, isMultiline: allowMultiline, isReadOnly: true));
     }
 
     public void StartProgressBarUpdater()
     {
-        // TODO: Implement
+        if (progressUpdaterCts is not null)
+        {
+            ScriptWarning("Warning - there is another progress bar updater task running in the background.");
+            return;
+        }
+
+        progressUpdaterCts = new CancellationTokenSource();
+        progressUpdater = Task.Run(() => ProgressUpdater(progressUpdaterCts.Token));
     }
 
-    public Task StopProgressBarUpdater()
+    public async Task StopProgressBarUpdater()
     {
-        // TODO: Implement
-        return Task.CompletedTask;
+        if (progressUpdaterCts is null || progressUpdater is null)
+            return;
+
+        CancellationTokenSource cts = progressUpdaterCts;
+        Task updater = progressUpdater;
+
+        cts.Cancel();
+
+        Task completed = await Task.WhenAny(updater, Task.Delay(2000));
+        if (completed != updater)
+        {
+            ScriptError("Stopping the progress bar updater task failed. Restarting the application is recommended.", "Script error", SetConsoleText: false);
+            return;
+        }
+
+        await updater;
+        cts.Dispose();
+        progressUpdaterCts = null;
+        progressUpdater = null;
     }
 
     public void UpdateProgressBar(string message, string status, double progressValue, double maxValue)
@@ -426,4 +621,105 @@ public class ScriptGlobals : IScriptInterface, IDisposable
             loaderWindow?.SetValue(loaderValue);
         });
     }
+
+    private Task ShowSearchOutput(string title, string query, int resultsCount, IEnumerable<KeyValuePair<string, List<(int lineNum, string codeLine)>>> resultsDict, IEnumerable<string>? failedList)
+    {
+        StringBuilder output = new();
+        output.AppendLine($"Query: {query}");
+        output.AppendLine($"Results: {resultsCount}");
+        output.AppendLine();
+
+        foreach ((string codeName, List<(int lineNum, string codeLine)> results) in resultsDict)
+        {
+            output.AppendLine(codeName);
+            foreach ((int lineNum, string codeLine) in results)
+            {
+                output.Append("  ");
+                output.Append(lineNum);
+                output.Append(": ");
+                output.AppendLine(codeLine);
+            }
+            output.AppendLine();
+        }
+
+        if (failedList is not null)
+        {
+            string[] failures = failedList.ToArray();
+            if (failures.Length > 0)
+            {
+                output.AppendLine("Failed:");
+                foreach (string failed in failures)
+                    output.AppendLine($"  {failed}");
+            }
+        }
+
+        if (mainVM.View is not { } view)
+        {
+            SetUMTConsoleText(output.ToString());
+            return Task.CompletedTask;
+        }
+
+        RunOnMainThread(() => view.TextBoxDialog("Search results", output.ToString(), title: title, isMultiline: true, isReadOnly: true));
+        return Task.CompletedTask;
+    }
+
+    private void ShowMessageDialogIfPossible(string message, string title)
+    {
+        if (mainVM.View is null)
+            return;
+
+        RunOnMainThread(() => mainVM.View.MessageDialog(message, title));
+    }
+
+    private void ProgressUpdater(CancellationToken token)
+    {
+        Stopwatch frameTimer = new();
+        Stopwatch? stopTimeout = null;
+        int previousValue = Volatile.Read(ref loaderValue);
+
+        while (true)
+        {
+            frameTimer.Restart();
+
+            int currentValue = Volatile.Read(ref loaderValue);
+            UpdateProgressValue(currentValue);
+
+            if (token.IsCancellationRequested)
+            {
+                if (previousValue >= currentValue)
+                    return;
+
+                stopTimeout ??= Stopwatch.StartNew();
+                if (stopTimeout.ElapsedMilliseconds >= 500)
+                    return;
+            }
+            else if (currentValue != previousValue)
+            {
+                stopTimeout = null;
+            }
+
+            previousValue = currentValue;
+
+            int sleep = (int)Math.Max(0, 33 - frameTimer.ElapsedMilliseconds);
+            if (sleep > 0)
+                Thread.Sleep(sleep);
+        }
+    }
+
+    private T RunOnMainThread<T>(Func<T> action)
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+            return action();
+
+        return Dispatcher.UIThread.Invoke(action);
+    }
+
+    private T RunOnMainThread<T>(Func<Task<T>> action)
+    {
+        if (Dispatcher.UIThread.CheckAccess())
+            return action().WaitOnDispatcherFrame();
+
+        return Dispatcher.UIThread.Invoke(() => action().WaitOnDispatcherFrame());
+    }
+
 }

--- a/UndertaleModToolAvalonia/Core/SettingsFile.cs
+++ b/UndertaleModToolAvalonia/Core/SettingsFile.cs
@@ -2,6 +2,8 @@ using System;
 using System.IO;
 using System.Reflection;
 using System.Text.Json;
+using System.Threading.Tasks;
+using Avalonia;
 using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
 using Microsoft.Extensions.DependencyInjection;
@@ -65,11 +67,7 @@ public partial class SettingsFile
                 string xaml = File.ReadAllText(stylesPath);
                 Styles styles = AvaloniaRuntimeXamlLoader.Parse<Styles>(xaml);
 
-                if (App.CurrentCustomStyles is not null)
-                    App.Current!.Styles.Remove(App.CurrentCustomStyles);
-
-                App.CurrentCustomStyles = styles;
-                App.Current!.Styles.Add(styles);
+                TryApplyCustomStyles(styles, App.Current);
             }
             catch (Exception e)
             {
@@ -80,23 +78,54 @@ public partial class SettingsFile
         return settings;
     }
 
+    internal static bool TryApplyCustomStyles(Styles styles, Application? app)
+    {
+        if (app is null)
+            return false;
+
+        if (App.CurrentCustomStyles is not null)
+            app.Styles.Remove(App.CurrentCustomStyles);
+
+        App.CurrentCustomStyles = styles;
+        app.Styles.Add(styles);
+        return true;
+    }
+
     public async void Save()
     {
+        await SaveTask();
+    }
+
+    public Task<bool> SaveTask()
+    {
         string roamingAppData = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "UndertaleModToolAvalonia");
-        Directory.CreateDirectory(roamingAppData);
+        return SaveTask(Path.Join(roamingAppData, "Settings.json"));
+    }
 
-        string json = JsonSerializer.Serialize(this, new JsonSerializerOptions()
-        {
-            WriteIndented = true,
-        });
-
+    internal async Task<bool> SaveTask(string settingsPath)
+    {
         try
         {
-            File.WriteAllText(Path.Join(roamingAppData, "Settings.json"), json);
+            string? directory = Path.GetDirectoryName(settingsPath);
+            if (!string.IsNullOrWhiteSpace(directory))
+                Directory.CreateDirectory(directory);
+
+            string json = JsonSerializer.Serialize(this, new JsonSerializerOptions()
+            {
+                WriteIndented = true,
+            });
+
+            File.WriteAllText(settingsPath, json);
+            return true;
         }
         catch (Exception e)
         {
-            await MainVM.View!.MessageDialog($"Error when saving settings file: {e.Message}");
+            string message = $"Error when saving settings file: {e.Message}";
+            if (MainVM?.View is { } view)
+                await view.MessageDialog(message);
+            else
+                MainVM?.LazyErrorMessages.Add(message);
+            return false;
         }
     }
 
@@ -121,7 +150,7 @@ public partial class SettingsFile
                 ThemeValue.SystemDefault => ThemeVariant.Default,
                 ThemeValue.Light => ThemeVariant.Light,
                 ThemeValue.Dark => ThemeVariant.Dark,
-                _ => throw new NotImplementedException(),
+                _ => ThemeVariant.Default,
             };
         }
     }
@@ -131,6 +160,9 @@ public partial class SettingsFile
     public bool OpenNewResourceAfterCreatingIt { get; set; } = false;
     public bool EnableSyntaxHighlighting { get; set; } = true;
     public bool AutomaticallyCompileAndDecompileCodeOnLostFocus { get; set; } = true;
+
+    [Notify]
+    private bool _AutomaticallyRenderImagePreviews = true;
 
     public bool EnableRoomGridByDefault { get; set; } = false;
     public uint DefaultRoomGridWidth { get; set; } = 20;

--- a/UndertaleModToolAvalonia/Helpers/EnumTypeToValuesConverter.cs
+++ b/UndertaleModToolAvalonia/Helpers/EnumTypeToValuesConverter.cs
@@ -18,6 +18,6 @@ public class EnumTypeToValuesConverter : IValueConverter
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        throw new NotImplementedException();
+        return BindingOperations.DoNothing;
     }
 }

--- a/UndertaleModToolAvalonia/Helpers/EventsToExtendedEventConverter.cs
+++ b/UndertaleModToolAvalonia/Helpers/EventsToExtendedEventConverter.cs
@@ -29,7 +29,7 @@ public class EventsToExtendedEventConverter : IValueConverter
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        throw new NotImplementedException();
+        return BindingOperations.DoNothing;
     }
 }
 

--- a/UndertaleModToolAvalonia/Helpers/LevelToWidthConverter.cs
+++ b/UndertaleModToolAvalonia/Helpers/LevelToWidthConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using Avalonia.Data;
 using Avalonia.Data.Converters;
 
 namespace UndertaleModToolAvalonia;
@@ -17,6 +18,6 @@ public class LevelToWidthConverter : IValueConverter
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        throw new NotImplementedException();
+        return BindingOperations.DoNothing;
     }
 }

--- a/UndertaleModToolAvalonia/Helpers/RoomItemToContextMenuConverter.cs
+++ b/UndertaleModToolAvalonia/Helpers/RoomItemToContextMenuConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using Avalonia.Controls;
+using Avalonia.Data;
 using Avalonia.Data.Converters;
 using UndertaleModLib.Models;
 
@@ -55,6 +56,6 @@ public class RoomItemToContextMenuConverter : IValueConverter
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        throw new NotImplementedException();
+        return BindingOperations.DoNothing;
     }
 }

--- a/UndertaleModToolAvalonia/Helpers/TreeDataGridItemToContextMenuConverter.cs
+++ b/UndertaleModToolAvalonia/Helpers/TreeDataGridItemToContextMenuConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using Avalonia.Controls;
+using Avalonia.Data;
 using Avalonia.Data.Converters;
 using UndertaleModLib;
 
@@ -28,6 +29,6 @@ public class TreeDataGridItemToContextMenuConverter : IValueConverter
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        throw new NotImplementedException();
+        return BindingOperations.DoNothing;
     }
 }

--- a/UndertaleModToolAvalonia/Helpers/VersionCompareConverter.cs
+++ b/UndertaleModToolAvalonia/Helpers/VersionCompareConverter.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Globalization;
-using System.Linq;
 using Avalonia.Data;
 using Avalonia.Data.Converters;
 
@@ -28,18 +27,19 @@ public class VersionCompareConverter : IValueConverter
 
             string operation = "GE";
 
-            if (compareString.StartsWith("GE"))
+            if (compareString.StartsWith("GE", StringComparison.Ordinal))
             {
                 operation = "GE";
                 compareString = compareString[("GE".Length)..];
             }
-            else if (compareString.StartsWith("L"))
+            else if (compareString.StartsWith("L", StringComparison.Ordinal))
             {
                 operation = "L";
                 compareString = compareString[("L".Length)..];
             }
 
-            uint[] versionCompareList = [.. compareString.Split('.').Select(x => uint.Parse(x))];
+            if (!TryParseVersion(compareString, out uint[] versionCompareList))
+                return VersionCompareError(compareString);
 
             for (int i = 0; i < versionCompareList.Length; i++)
             {
@@ -56,11 +56,41 @@ public class VersionCompareConverter : IValueConverter
                 return false;
         }
 
-        return new BindingNotification(new InvalidOperationException(), BindingErrorType.Error);
+        return VersionCompareError(parameter);
     }
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        throw new NotImplementedException();
+        return BindingOperations.DoNothing;
+    }
+
+    private static bool TryParseVersion(string compareString, out uint[] versionCompareList)
+    {
+        versionCompareList = [];
+
+        string[] parts = compareString.Split('.');
+        if (parts.Length == 0 || parts.Length > 4)
+            return false;
+
+        versionCompareList = new uint[parts.Length];
+        for (int i = 0; i < parts.Length; i++)
+        {
+            if (!uint.TryParse(parts[i], NumberStyles.None, CultureInfo.InvariantCulture, out uint versionPart))
+            {
+                versionCompareList = [];
+                return false;
+            }
+
+            versionCompareList[i] = versionPart;
+        }
+
+        return true;
+    }
+
+    private static BindingNotification VersionCompareError(object? parameter)
+    {
+        return new BindingNotification(
+            new InvalidOperationException($"Invalid version comparison parameter: {parameter ?? "<null>"}"),
+            BindingErrorType.Error);
     }
 }

--- a/UndertaleModToolAvalonia/Properties/AssemblyInfo.cs
+++ b/UndertaleModToolAvalonia/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UndertaleModToolAvalonia.Tests")]

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleBackgroundView.axaml
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleBackgroundView.axaml
@@ -101,10 +101,17 @@
                     IsVisible="{Binding $parent[l:MainView].((l:MainViewModel)DataContext).DataVersion,
                     Converter={StaticResource VersionCompareConverter},
                     ConverterParameter=GE2}">Auto tile IDs (no animated tiles)</Button>
+
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="{Binding PreviewStatus}" VerticalAlignment="Center" />
+                <Button Command="{Binding RenderPreview}"
+                        IsVisible="{Binding !IsPreviewRendered}">Render preview</Button>
+            </StackPanel>
         
             <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" HorizontalAlignment="Center"
                             MaxHeight="{Binding $parent[ScrollViewer].Viewport.Height}">
-                <l:SKImageViewer Image="{Binding Background.Texture}" />
+                <l:SKImageViewer Image="{Binding Background.Texture}"
+                                 IsRenderingEnabled="{Binding IsPreviewRendered}" />
             </ScrollViewer>
         </StackPanel>
     </ScrollViewer>

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleBackgroundViewModel.cs
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleBackgroundViewModel.cs
@@ -1,16 +1,79 @@
 ﻿using UndertaleModLib;
 using UndertaleModLib.Models;
+using System;
+using System.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
+using PropertyChanged.SourceGenerator;
 
 namespace UndertaleModToolAvalonia;
 
 public partial class UndertaleBackgroundViewModel : IUndertaleResourceViewModel
 {
+    public MainViewModel MainVM;
     public UndertaleResource Resource => Background;
     public UndertaleBackground Background { get; }
 
-    public UndertaleBackgroundViewModel(UndertaleBackground background)
+    [Notify]
+    private bool _IsPreviewRendered;
+
+    [Notify]
+    private string _PreviewStatus = "";
+
+    public UndertaleBackgroundViewModel(UndertaleBackground background, IServiceProvider serviceProvider)
     {
+        MainVM = serviceProvider.GetRequiredService<MainViewModel>();
+
         Background = background;
+        ResetPreviewState();
+    }
+
+    public void OnAttached()
+    {
+        if (MainVM.Settings is not null)
+            MainVM.Settings.PropertyChanged += Settings_PropertyChanged;
+    }
+
+    public void OnDetached()
+    {
+        if (MainVM.Settings is not null)
+            MainVM.Settings.PropertyChanged -= Settings_PropertyChanged;
+    }
+
+    public void RenderPreview()
+    {
+        IsPreviewRendered = HasPreviewImage();
+        UpdatePreviewStatus();
+    }
+
+    void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(SettingsFile.AutomaticallyRenderImagePreviews))
+            ResetPreviewState();
+    }
+
+    void ResetPreviewState()
+    {
+        IsPreviewRendered = ShouldRenderImagePreviewsAutomatically() && HasPreviewImage();
+        UpdatePreviewStatus();
+    }
+
+    void UpdatePreviewStatus()
+    {
+        PreviewStatus = Background.Texture?.TexturePage?.TextureData?.Image is null
+            ? "No texture image loaded."
+            : IsPreviewRendered
+                ? "Texture preview rendered."
+                : "Texture preview not rendered.";
+    }
+
+    bool HasPreviewImage()
+    {
+        return Background.Texture?.TexturePage?.TextureData?.Image is not null;
+    }
+
+    bool ShouldRenderImagePreviewsAutomatically()
+    {
+        return MainVM.Settings?.AutomaticallyRenderImagePreviews ?? true;
     }
 
     public static UndertaleBackground.TileID CreateTileID() => new();

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleCodeViewModel.cs
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleCodeViewModel.cs
@@ -74,8 +74,11 @@ public partial class UndertaleCodeViewModel : IUndertaleResourceViewModel
             }
             catch (Underanalyzer.Decompiler.DecompilerException e)
             {
-                loaderWindow?.EnsureShown();
-                await MainVM.View!.MessageDialog(e.ToString(), title: "GML decompilation error");
+                if (MainVM.View is { } view)
+                {
+                    loaderWindow?.EnsureShown();
+                    await view.MessageDialog(e.ToString(), title: "GML decompilation error");
+                }
                 return false;
             }
         }
@@ -100,12 +103,15 @@ public partial class UndertaleCodeViewModel : IUndertaleResourceViewModel
 
         if (!result.Successful)
         {
-            loaderWindow?.EnsureShown();
-            MessageWindow.Result undoChanges = await MainVM.View!.MessageDialog(result.PrintAllErrors(codeEntryNames: false)
-                + "\n\nUndo changes?", title: "GML compilation error", MessageWindow.Buttons.YesNo);
-            if (undoChanges == MessageWindow.Result.Yes)
+            if (MainVM.View is { } view)
             {
-                await DecompileToGML();
+                loaderWindow?.EnsureShown();
+                MessageWindow.Result undoChanges = await view.MessageDialog(result.PrintAllErrors(codeEntryNames: false)
+                    + "\n\nUndo changes?", title: "GML compilation error", MessageWindow.Buttons.YesNo);
+                if (undoChanges == MessageWindow.Result.Yes)
+                {
+                    await DecompileToGML();
+                }
             }
             return false;
         }
@@ -133,8 +139,11 @@ public partial class UndertaleCodeViewModel : IUndertaleResourceViewModel
         }
         catch (Exception e)
         {
-            loaderWindow?.EnsureShown();
-            await MainVM.View!.MessageDialog(e.ToString(), title: "ASM decompilation error");
+            if (MainVM.View is { } view)
+            {
+                loaderWindow?.EnsureShown();
+                await view.MessageDialog(e.ToString(), title: "ASM decompilation error");
+            }
             return false;
         }
 
@@ -151,11 +160,14 @@ public partial class UndertaleCodeViewModel : IUndertaleResourceViewModel
         if (MainVM.Project is not null && MainVM.Project.TryGetCodeSource(Code, out _))
         {
             // The user really shouldn't be editing disassembly - warn them about this in detail
-            loaderWindow?.EnsureShown();
-            await MainVM.View!.MessageDialog("Editing disassembly while in an open project (even through scripts) can cause " +
-                "desyncs with source code in the project.\n\n" +
-                "The source code will not change unless you directly modify it, " +
-                "or if you remove the code asset from the project entirely.");
+            if (MainVM.View is { } view)
+            {
+                loaderWindow?.EnsureShown();
+                await view.MessageDialog("Editing disassembly while in an open project (even through scripts) can cause " +
+                    "desyncs with source code in the project.\n\n" +
+                    "The source code will not change unless you directly modify it, " +
+                    "or if you remove the code asset from the project entirely.");
+            }
         }
 
         try
@@ -166,12 +178,15 @@ public partial class UndertaleCodeViewModel : IUndertaleResourceViewModel
         }
         catch (Exception e)
         {
-            loaderWindow?.EnsureShown();
-            MessageWindow.Result undoChanges = await MainVM.View!.MessageDialog(e.ToString()
-                + "\n\nUndo changes?", title: "ASM compilation error", MessageWindow.Buttons.YesNo);
-            if (undoChanges == MessageWindow.Result.Yes)
+            if (MainVM.View is { } view)
             {
-                await DecompileToASM();
+                loaderWindow?.EnsureShown();
+                MessageWindow.Result undoChanges = await view.MessageDialog(e.ToString()
+                    + "\n\nUndo changes?", title: "ASM compilation error", MessageWindow.Buttons.YesNo);
+                if (undoChanges == MessageWindow.Result.Yes)
+                {
+                    await DecompileToASM();
+                }
             }
 
             return false;
@@ -187,18 +202,21 @@ public partial class UndertaleCodeViewModel : IUndertaleResourceViewModel
 
     void CodeProcessStart()
     {
-        loaderWindow = MainVM.View!.LoaderOpen();
+        if (MainVM.View is { } view)
+        {
+            loaderWindow = view.LoaderOpen();
+            lastFocusedElement = view.GetFocusedElement();
+        }
 
         IsCodeProcessing = true;
 
         View?.SaveCaretOffsets();
-        lastFocusedElement = MainVM.View.GetFocusedElement();
         MainVM.IsEnabled = false;
     }
 
     void CodeProcessEnd()
     {
-        loaderWindow!.Close();
+        loaderWindow?.Close();
         loaderWindow = null;
 
         IsCodeProcessing = false;

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleEmbeddedAudioView.axaml
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleEmbeddedAudioView.axaml
@@ -8,17 +8,20 @@
              x:DataType="l:UndertaleEmbeddedAudioViewModel">
     <ScrollViewer>
         <StackPanel Classes="PaddedProperties">
-            <StackPanel Orientation="Horizontal">
-                <TextBlock Text="WAV data, length: " />
-                <TextBlock Text="{Binding EmbeddedAudio.Data.Length}" />
-            </StackPanel>
+            <Grid l:AutoGridBehavior.Enable="True" ColumnDefinitions="1*,3*">
+                <Label>Format</Label>
+                <TextBlock Text="{Binding AudioFormat}" TextWrapping="Wrap" />
+
+                <Label>Size</Label>
+                <TextBlock Text="{Binding AudioSize}" TextWrapping="Wrap" />
+
+                <Label>Linked sounds</Label>
+                <TextBlock Text="{Binding LinkedSoundsSummary}" TextWrapping="Wrap" />
+            </Grid>
 
             <StackPanel Orientation="Horizontal">
                 <Button Command="{Binding ImportAudio}">Import audio</Button>
                 <Button Command="{Binding ExportAudio}">Export audio</Button>
-            </StackPanel>
-
-            <StackPanel Orientation="Horizontal">
                 <Button Command="{Binding PlayAudio}">Play audio</Button>
                 <Button Command="{Binding StopAudio}">Stop audio</Button>
             </StackPanel>

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleEmbeddedAudioViewModel.cs
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleEmbeddedAudioViewModel.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using Avalonia.Platform.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using PropertyChanged.SourceGenerator;
 using UndertaleModLib;
 using UndertaleModLib.Models;
 
@@ -14,6 +17,15 @@ public partial class UndertaleEmbeddedAudioViewModel : IUndertaleResourceViewMod
     public UndertaleResource Resource => EmbeddedAudio;
     public UndertaleEmbeddedAudio EmbeddedAudio { get; }
 
+    [Notify]
+    private string _AudioFormat = "";
+
+    [Notify]
+    private string _AudioSize = "";
+
+    [Notify]
+    private string _LinkedSoundsSummary = "";
+
     AudioPlayer? audioPlayer = null;
 
     public UndertaleEmbeddedAudioViewModel(UndertaleEmbeddedAudio embeddedAudio, IServiceProvider serviceProvider)
@@ -21,6 +33,7 @@ public partial class UndertaleEmbeddedAudioViewModel : IUndertaleResourceViewMod
         MainVM = serviceProvider.GetRequiredService<MainViewModel>();
 
         EmbeddedAudio = embeddedAudio;
+        RefreshAudioDetails();
     }
 
     public void OnDetached()
@@ -30,11 +43,33 @@ public partial class UndertaleEmbeddedAudioViewModel : IUndertaleResourceViewMod
 
     public async void PlayAudio()
     {
-        audioPlayer?.Stop();
-        audioPlayer = new(EmbeddedAudio.Data);
+        await PlayAudioTask();
     }
 
-    public async void StopAudio()
+    public async Task<bool> PlayAudioTask()
+    {
+        StopAudio();
+
+        byte[] data = EmbeddedAudio.Data ?? [];
+
+        if (data.Length == 0)
+            return false;
+
+        try
+        {
+            audioPlayer = new(data);
+            return true;
+        }
+        catch (Exception e)
+        {
+            if (MainVM.View is not null)
+                await MainVM.View.MessageDialog($"Failed to play audio: {e.Message}");
+
+            return false;
+        }
+    }
+
+    public void StopAudio()
     {
         audioPlayer?.Stop();
         audioPlayer = null;
@@ -42,24 +77,43 @@ public partial class UndertaleEmbeddedAudioViewModel : IUndertaleResourceViewMod
 
     public async void ImportAudio()
     {
-        IReadOnlyList<IStorageFile> files = await MainVM.View!.OpenFileDialog(new FilePickerOpenOptions
+        await ImportAudioTask();
+    }
+
+    public async Task<bool> ImportAudioTask()
+    {
+        if (MainVM.View is not { } view)
+            return false;
+
+        IReadOnlyList<IStorageFile> files = await view.OpenFileDialog(new FilePickerOpenOptions
         {
             Title = "Import audio",
             FileTypeFilter = FilePickerFileTypes.WAV,
         });
 
         if (files.Count != 1)
-            return;
+            return false;
 
         using (Stream stream = await files[0].OpenReadAsync())
         {
             await ImportExport.ImportEmbeddedAudio(EmbeddedAudio, stream);
         }
+
+        RefreshAudioDetails();
+        return true;
     }
 
     public async void ExportAudio()
     {
-        IStorageFile? file = await MainVM.View!.SaveFileDialog(new FilePickerSaveOptions()
+        await ExportAudioTask();
+    }
+
+    public async Task<bool> ExportAudioTask()
+    {
+        if (MainVM.View is not { } view)
+            return false;
+
+        IStorageFile? file = await view.SaveFileDialog(new FilePickerSaveOptions()
         {
             Title = "Export audio",
             FileTypeChoices = FilePickerFileTypes.WAV,
@@ -68,11 +122,43 @@ public partial class UndertaleEmbeddedAudioViewModel : IUndertaleResourceViewMod
         });
 
         if (file is null)
-            return;
+            return false;
 
         using (Stream stream = await file.OpenWriteAsync())
         {
             await ImportExport.ExportEmbeddedAudio(EmbeddedAudio, stream);
         }
+
+        return true;
+    }
+
+    void RefreshAudioDetails()
+    {
+        byte[] data = EmbeddedAudio.Data ?? [];
+
+        AudioFormat = AudioMetadata.DescribeFormat(data);
+        AudioSize = AudioMetadata.FormatByteCount(data.Length);
+        LinkedSoundsSummary = GetLinkedSoundsSummary();
+    }
+
+    string GetLinkedSoundsSummary()
+    {
+        if (MainVM.Data?.Sounds is null)
+            return "No data file loaded.";
+
+        string[] linkedSounds = MainVM.Data.Sounds
+            .Select((sound, index) => new { Sound = sound, Index = index })
+            .Where(entry => entry.Sound.AudioFile == EmbeddedAudio)
+            .Take(5)
+            .Select(entry => $"#{entry.Index} {entry.Sound.Name?.Content ?? "(unnamed)"}")
+            .ToArray();
+
+        int linkedCount = MainVM.Data.Sounds.Count(sound => sound.AudioFile == EmbeddedAudio);
+
+        if (linkedCount == 0)
+            return "Not referenced by any sound entry.";
+
+        string suffix = linkedCount > linkedSounds.Length ? $", +{linkedCount - linkedSounds.Length} more" : "";
+        return $"Used by {linkedCount} sound(s): {string.Join(", ", linkedSounds)}{suffix}.";
     }
 }

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleEmbeddedImageView.axaml
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleEmbeddedImageView.axaml
@@ -17,9 +17,16 @@
                 <l:UndertaleResourceReferenceView Reference="{Binding EmbeddedImage.TextureEntry}" ReferenceType="undertalem:UndertaleTexturePageItem" />
             </Grid>
 
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="{Binding PreviewStatus}" VerticalAlignment="Center" />
+                <Button Command="{Binding RenderPreview}"
+                        IsVisible="{Binding !IsPreviewRendered}">Render preview</Button>
+            </StackPanel>
+
             <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" HorizontalAlignment="Center"
                           MaxHeight="{Binding $parent[ScrollViewer].Viewport.Height}">
-                <l:SKImageViewer Image="{Binding EmbeddedImage.TextureEntry}" />
+                <l:SKImageViewer Image="{Binding EmbeddedImage.TextureEntry}"
+                                 IsRenderingEnabled="{Binding IsPreviewRendered}" />
             </ScrollViewer>
         </StackPanel>
     </ScrollViewer>

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleEmbeddedImageViewModel.cs
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleEmbeddedImageViewModel.cs
@@ -1,15 +1,78 @@
 ﻿using UndertaleModLib;
 using UndertaleModLib.Models;
+using System;
+using System.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
+using PropertyChanged.SourceGenerator;
 
 namespace UndertaleModToolAvalonia;
 
 public partial class UndertaleEmbeddedImageViewModel : IUndertaleResourceViewModel
 {
+    public MainViewModel MainVM;
     public UndertaleResource Resource => EmbeddedImage;
     public UndertaleEmbeddedImage EmbeddedImage { get; }
 
-    public UndertaleEmbeddedImageViewModel(UndertaleEmbeddedImage embeddedImage)
+    [Notify]
+    private bool _IsPreviewRendered;
+
+    [Notify]
+    private string _PreviewStatus = "";
+
+    public UndertaleEmbeddedImageViewModel(UndertaleEmbeddedImage embeddedImage, IServiceProvider serviceProvider)
     {
+        MainVM = serviceProvider.GetRequiredService<MainViewModel>();
+
         EmbeddedImage = embeddedImage;
+        ResetPreviewState();
+    }
+
+    public void OnAttached()
+    {
+        if (MainVM.Settings is not null)
+            MainVM.Settings.PropertyChanged += Settings_PropertyChanged;
+    }
+
+    public void OnDetached()
+    {
+        if (MainVM.Settings is not null)
+            MainVM.Settings.PropertyChanged -= Settings_PropertyChanged;
+    }
+
+    public void RenderPreview()
+    {
+        IsPreviewRendered = HasPreviewImage();
+        UpdatePreviewStatus();
+    }
+
+    void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(SettingsFile.AutomaticallyRenderImagePreviews))
+            ResetPreviewState();
+    }
+
+    void ResetPreviewState()
+    {
+        IsPreviewRendered = ShouldRenderImagePreviewsAutomatically() && HasPreviewImage();
+        UpdatePreviewStatus();
+    }
+
+    void UpdatePreviewStatus()
+    {
+        PreviewStatus = EmbeddedImage.TextureEntry?.TexturePage?.TextureData?.Image is null
+            ? "No texture image loaded."
+            : IsPreviewRendered
+                ? "Texture preview rendered."
+                : "Texture preview not rendered.";
+    }
+
+    bool HasPreviewImage()
+    {
+        return EmbeddedImage.TextureEntry?.TexturePage?.TextureData?.Image is not null;
+    }
+
+    bool ShouldRenderImagePreviewsAutomatically()
+    {
+        return MainVM.Settings?.AutomaticallyRenderImagePreviews ?? true;
     }
 }

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleEmbeddedTextureView.axaml
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleEmbeddedTextureView.axaml
@@ -8,6 +8,7 @@
              x:DataType="l:UndertaleEmbeddedTextureViewModel">
     <UserControl.Resources>
         <l:VersionCompareConverter x:Key="VersionCompareConverter" />
+        <l:ZoomConverter x:Key="ZoomConverter" />
     </UserControl.Resources>
 
     <ScrollViewer>
@@ -35,13 +36,44 @@
                 <Button Command="{Binding ImportImage}">Import image</Button>
                 <Button Command="{Binding ExportImage}">Export image</Button>
                 <Button Command="{Binding ExportImageAsPNG}">Export image as PNG</Button>
+                <TextBlock Text="Zoom" VerticalAlignment="Center" Margin="12,0,4,0" />
+                <Button Command="{Binding ZoomOut}">-</Button>
+                <TextBox Text="{Binding PreviewZoom, Converter={StaticResource ZoomConverter}}" Width="70" />
+                <Button Command="{Binding ZoomIn}">+</Button>
+                <Button Command="{Binding ZoomReset}">100%</Button>
             </StackPanel>
+
+            <Grid ColumnDefinitions="*,Auto,Auto" Classes="PaddedProperties">
+                <TextBlock Grid.Column="0"
+                           Text="{Binding SelectedTexturePageItemDescription}"
+                           TextWrapping="Wrap"
+                           VerticalAlignment="Center" />
+                <Button Grid.Column="1"
+                        Command="{Binding OpenSelectedTexturePageItem}"
+                        IsEnabled="{Binding SelectedTexturePageItem, Converter={x:Static ObjectConverters.IsNotNull}}">
+                    Open selected item
+                </Button>
+                <Button Grid.Column="2"
+                        Command="{Binding OpenSelectedTexturePageItemInNewTab}"
+                        IsEnabled="{Binding SelectedTexturePageItem, Converter={x:Static ObjectConverters.IsNotNull}}">
+                    Open in new tab
+                </Button>
+            </Grid>
             
-            <!-- TODO: Click on item to open -->
             <!-- TODO: Failed to load message -->
+            <Grid ColumnDefinitions="*,Auto" Classes="PaddedProperties">
+                <TextBlock Text="{Binding PreviewStatus}" VerticalAlignment="Center" />
+                <Button Grid.Column="1"
+                        Command="{Binding RenderPreview}"
+                        IsVisible="{Binding !IsPreviewRendered}">Render preview</Button>
+            </Grid>
             <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" HorizontalAlignment="Center"
                           MaxHeight="{Binding $parent[ScrollViewer].Viewport.Height}">
-                <l:SKImageViewer Image="{Binding EmbeddedTexture.TextureData.Image}" />
+                <l:SKImageViewer Image="{Binding EmbeddedTexture.TextureData.Image}"
+                                 TexturePageItems="{Binding TexturePageItems}"
+                                 SelectedTexturePageItem="{Binding SelectedTexturePageItem, Mode=TwoWay}"
+                                 Zoom="{Binding PreviewZoom, Mode=TwoWay}"
+                                 IsRenderingEnabled="{Binding IsPreviewRendered}" />
             </ScrollViewer>
         </StackPanel>
     </ScrollViewer>

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleEmbeddedTextureViewModel.cs
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleEmbeddedTextureViewModel.cs
@@ -1,8 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using Avalonia.Platform.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using PropertyChanged.SourceGenerator;
 using UndertaleModLib;
 using UndertaleModLib.Models;
 using UndertaleModLib.Util;
@@ -14,34 +18,179 @@ public partial class UndertaleEmbeddedTextureViewModel : IUndertaleResourceViewM
     public MainViewModel MainVM;
     public UndertaleResource Resource => EmbeddedTexture;
     public UndertaleEmbeddedTexture EmbeddedTexture { get; }
+    public IReadOnlyList<UndertaleTexturePageItem> TexturePageItems { get; }
+
+    [Notify]
+    private UndertaleTexturePageItem? _SelectedTexturePageItem;
+
+    [Notify]
+    private string _SelectedTexturePageItemDescription = "Click a texture region to select a page item.";
+
+    [Notify]
+    private double _PreviewZoom = 1;
+
+    [Notify]
+    private bool _IsPreviewRendered;
+
+    [Notify]
+    private string _PreviewStatus = "";
 
     public UndertaleEmbeddedTextureViewModel(UndertaleEmbeddedTexture embeddedTexture, IServiceProvider serviceProvider)
     {
         MainVM = serviceProvider.GetRequiredService<MainViewModel>();
 
         EmbeddedTexture = embeddedTexture;
+        TexturePageItems = MainVM.Data?.TexturePageItems?
+            .Where(item => item.TexturePage == EmbeddedTexture)
+            .ToList() ?? [];
+        SelectedTexturePageItemDescription = TexturePageItems.Count == 0
+            ? "No texture page items reference this texture."
+            : "Click a texture region to select a page item.";
+        ResetPreviewState();
+    }
+
+    public void OnAttached()
+    {
+        if (MainVM.Settings is not null)
+            MainVM.Settings.PropertyChanged += Settings_PropertyChanged;
+    }
+
+    public void OnDetached()
+    {
+        if (MainVM.Settings is not null)
+            MainVM.Settings.PropertyChanged -= Settings_PropertyChanged;
+    }
+
+    private void OnSelectedTexturePageItemChanged()
+    {
+        if (SelectedTexturePageItem is null)
+        {
+            SelectedTexturePageItemDescription = TexturePageItems.Count == 0
+                ? "No texture page items reference this texture."
+                : "Click a texture region to select a page item.";
+            return;
+        }
+
+        int index = MainVM.Data?.TexturePageItems.IndexOf(SelectedTexturePageItem) ?? -1;
+        SelectedTexturePageItemDescription =
+            $"Page item {index}: source {SelectedTexturePageItem.SourceX},{SelectedTexturePageItem.SourceY} " +
+            $"{SelectedTexturePageItem.SourceWidth}x{SelectedTexturePageItem.SourceHeight}; target " +
+            $"{SelectedTexturePageItem.TargetX},{SelectedTexturePageItem.TargetY} " +
+            $"{SelectedTexturePageItem.TargetWidth}x{SelectedTexturePageItem.TargetHeight}.";
+
+        if (MainVM.View is MainView mainView)
+            mainView.SelectValueInTree(SelectedTexturePageItem);
+    }
+
+    public void OpenSelectedTexturePageItem()
+    {
+        if (SelectedTexturePageItem is not null)
+            MainVM.TabOpen(SelectedTexturePageItem);
+    }
+
+    public void OpenSelectedTexturePageItemInNewTab()
+    {
+        if (SelectedTexturePageItem is not null)
+            MainVM.TabOpen(SelectedTexturePageItem, inNewTab: true);
+    }
+
+    public void ZoomIn()
+    {
+        PreviewZoom = Math.Min(32, PreviewZoom * 2);
+    }
+
+    public void ZoomOut()
+    {
+        PreviewZoom = Math.Max(0.125, PreviewZoom / 2);
+    }
+
+    public void ZoomReset()
+    {
+        PreviewZoom = 1;
+    }
+
+    private void OnPreviewZoomChanged()
+    {
+        if (double.IsNaN(PreviewZoom) || double.IsInfinity(PreviewZoom))
+        {
+            PreviewZoom = 1;
+            return;
+        }
+
+        PreviewZoom = Math.Clamp(PreviewZoom, 0.125, 32);
+    }
+
+    public void RenderPreview()
+    {
+        IsPreviewRendered = EmbeddedTexture.TextureData?.Image is not null;
+        UpdatePreviewStatus();
+    }
+
+    void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(SettingsFile.AutomaticallyRenderImagePreviews))
+            ResetPreviewState();
+    }
+
+    void ResetPreviewState()
+    {
+        IsPreviewRendered = ShouldRenderImagePreviewsAutomatically() && EmbeddedTexture.TextureData?.Image is not null;
+        UpdatePreviewStatus();
+    }
+
+    void UpdatePreviewStatus()
+    {
+        PreviewStatus = EmbeddedTexture.TextureData?.Image is null
+            ? "No texture image loaded."
+            : IsPreviewRendered
+                ? "Texture preview rendered."
+                : "Texture preview not rendered.";
+    }
+
+    bool ShouldRenderImagePreviewsAutomatically()
+    {
+        return MainVM.Settings?.AutomaticallyRenderImagePreviews ?? true;
     }
 
     public async void ImportImage()
     {
+        await ImportImageTask();
+    }
+
+    public async Task<bool> ImportImageTask()
+    {
+        if (MainVM.View is not { } view)
+            return false;
+
         // TODO: Allow formats other than PNG, either directly or to convert it
-        IReadOnlyList<IStorageFile> files = await MainVM.View!.OpenFileDialog(new FilePickerOpenOptions
+        IReadOnlyList<IStorageFile> files = await view.OpenFileDialog(new FilePickerOpenOptions
         {
             Title = "Import image",
             FileTypeFilter = FilePickerFileTypes.Image,
         });
 
         if (files.Count != 1)
-            return;
+            return false;
 
         using (Stream stream = await files[0].OpenReadAsync())
         {
             await ImportExport.ImportEmbeddedTexture(EmbeddedTexture, stream);
         }
+
+        ResetPreviewState();
+        return true;
     }
 
     public async void ExportImage()
     {
+        await ExportImageTask();
+    }
+
+    public async Task<bool> ExportImageTask()
+    {
+        if (MainVM.View is not { } view)
+            return false;
+
         (IReadOnlyList<FilePickerFileType> filePickerFileTypeList, string extension) type = EmbeddedTexture.TextureData.Image.Format switch
         {
             GMImage.ImageFormat.Png => (FilePickerFileTypes.PNG, "png"),
@@ -50,7 +199,7 @@ public partial class UndertaleEmbeddedTextureViewModel : IUndertaleResourceViewM
             _ => (FilePickerFileTypes.BIN, "bin"),
         };
 
-        IStorageFile? file = await MainVM.View!.SaveFileDialog(new FilePickerSaveOptions()
+        IStorageFile? file = await view.SaveFileDialog(new FilePickerSaveOptions()
         {
             Title = "Export image",
             FileTypeChoices = type.filePickerFileTypeList,
@@ -59,17 +208,27 @@ public partial class UndertaleEmbeddedTextureViewModel : IUndertaleResourceViewM
         });
 
         if (file is null)
-            return;
+            return false;
 
         using (Stream stream = await file.OpenWriteAsync())
         {
             await ImportExport.ExportEmbeddedTexture(EmbeddedTexture, stream);
         }
+
+        return true;
     }
 
     public async void ExportImageAsPNG()
     {
-        IStorageFile? file = await MainVM.View!.SaveFileDialog(new FilePickerSaveOptions()
+        await ExportImageAsPNGTask();
+    }
+
+    public async Task<bool> ExportImageAsPNGTask()
+    {
+        if (MainVM.View is not { } view)
+            return false;
+
+        IStorageFile? file = await view.SaveFileDialog(new FilePickerSaveOptions()
         {
             Title = "Export image as PNG",
             FileTypeChoices = FilePickerFileTypes.PNG,
@@ -78,11 +237,13 @@ public partial class UndertaleEmbeddedTextureViewModel : IUndertaleResourceViewM
         });
 
         if (file is null)
-            return;
+            return false;
 
         using (Stream stream = await file.OpenWriteAsync())
         {
             await ImportExport.ExportEmbeddedTextureAsPNG(EmbeddedTexture, stream);
         }
+
+        return true;
     }
 }

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleFontView.axaml
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleFontView.axaml
@@ -79,9 +79,16 @@
                 <TextBox Text="{Binding Font.LineHeight}" />
             </Grid>
 
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="{Binding PreviewStatus}" VerticalAlignment="Center" />
+                <Button Command="{Binding RenderPreview}"
+                        IsVisible="{Binding !IsPreviewRendered}">Render preview</Button>
+            </StackPanel>
+
             <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" HorizontalAlignment="Center"
                           MaxHeight="{Binding $parent[ScrollViewer].Viewport.Height}">
-                <l:SKImageViewer Image="{Binding Font.Texture}" />
+                <l:SKImageViewer Image="{Binding Font.Texture}"
+                                 IsRenderingEnabled="{Binding IsPreviewRendered}" />
             </ScrollViewer>
 
             <!-- TODO: Click and edit glyphs -->

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleFontViewModel.cs
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleFontViewModel.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System;
+using System.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
 using PropertyChanged.SourceGenerator;
 using UndertaleModLib;
 using UndertaleModLib.Models;
@@ -8,15 +11,74 @@ namespace UndertaleModToolAvalonia;
 
 public partial class UndertaleFontViewModel : IUndertaleResourceViewModel
 {
+    public MainViewModel MainVM;
     public UndertaleResource Resource => Font;
     public UndertaleFont Font { get; }
 
     [Notify]
     private UndertaleFont.Glyph? _GlyphsSelected;
 
-    public UndertaleFontViewModel(UndertaleFont font)
+    [Notify]
+    private bool _IsPreviewRendered;
+
+    [Notify]
+    private string _PreviewStatus = "";
+
+    public UndertaleFontViewModel(UndertaleFont font, IServiceProvider serviceProvider)
     {
+        MainVM = serviceProvider.GetRequiredService<MainViewModel>();
+
         Font = font;
+        ResetPreviewState();
+    }
+
+    public void OnAttached()
+    {
+        if (MainVM.Settings is not null)
+            MainVM.Settings.PropertyChanged += Settings_PropertyChanged;
+    }
+
+    public void OnDetached()
+    {
+        if (MainVM.Settings is not null)
+            MainVM.Settings.PropertyChanged -= Settings_PropertyChanged;
+    }
+
+    public void RenderPreview()
+    {
+        IsPreviewRendered = HasPreviewImage();
+        UpdatePreviewStatus();
+    }
+
+    void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(SettingsFile.AutomaticallyRenderImagePreviews))
+            ResetPreviewState();
+    }
+
+    void ResetPreviewState()
+    {
+        IsPreviewRendered = ShouldRenderImagePreviewsAutomatically() && HasPreviewImage();
+        UpdatePreviewStatus();
+    }
+
+    void UpdatePreviewStatus()
+    {
+        PreviewStatus = Font.Texture?.TexturePage?.TextureData?.Image is null
+            ? "No texture image loaded."
+            : IsPreviewRendered
+                ? "Texture preview rendered."
+                : "Texture preview not rendered.";
+    }
+
+    bool HasPreviewImage()
+    {
+        return Font.Texture?.TexturePage?.TextureData?.Image is not null;
+    }
+
+    bool ShouldRenderImagePreviewsAutomatically()
+    {
+        return MainVM.Settings?.AutomaticallyRenderImagePreviews ?? true;
     }
 
     public void GlyphsSelectedChanged(object? item)

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleGameObjectView.axaml
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleGameObjectView.axaml
@@ -27,10 +27,18 @@
                 <l:UndertaleResourceReferenceView Reference="{Binding GameObject.Sprite}" ReferenceType="undertalem:UndertaleSprite"/>
 
                 <Label>Image</Label>
-                <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" HorizontalAlignment="Center"
-                          MaxHeight="{Binding $parent[ScrollViewer].Viewport.Height}">
-                    <l:SKImageViewer Image="{Binding GameObject.Sprite.Textures[0].Texture}" />
-                </ScrollViewer>
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="{Binding PreviewStatus}" VerticalAlignment="Center" />
+                        <Button Command="{Binding RenderPreview}"
+                                IsVisible="{Binding !IsPreviewRendered}">Render preview</Button>
+                    </StackPanel>
+                    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" HorizontalAlignment="Center"
+                                  MaxHeight="{Binding $parent[ScrollViewer].Viewport.Height}">
+                        <l:SKImageViewer Image="{Binding PreviewImage}"
+                                         IsRenderingEnabled="{Binding IsPreviewRendered}" />
+                    </ScrollViewer>
+                </StackPanel>
 
                 <Label>Visible</Label>
                 <CheckBox IsChecked="{Binding GameObject.Visible}"/>

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleGameObjectViewModel.cs
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleGameObjectViewModel.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections;
+using System.ComponentModel;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using PropertyChanged.SourceGenerator;
 using UndertaleModLib;
 using UndertaleModLib.Models;
 
@@ -12,23 +14,86 @@ public partial class UndertaleGameObjectViewModel : IUndertaleResourceViewModel
     public MainViewModel MainVM;
     public UndertaleResource Resource => GameObject;
     public UndertaleGameObject GameObject { get; }
+    public UndertaleTexturePageItem? PreviewImage => GetPreviewImage();
+
+    [Notify]
+    private bool _IsPreviewRendered;
+
+    [Notify]
+    private string _PreviewStatus = "";
 
     public UndertaleGameObjectViewModel(UndertaleGameObject gameObject, IServiceProvider serviceProvider)
     {
         MainVM = serviceProvider.GetRequiredService<MainViewModel>();
 
         GameObject = gameObject;
+        ResetPreviewState();
+    }
+
+    public void OnAttached()
+    {
+        if (MainVM.Settings is not null)
+            MainVM.Settings.PropertyChanged += Settings_PropertyChanged;
+    }
+
+    public void OnDetached()
+    {
+        if (MainVM.Settings is not null)
+            MainVM.Settings.PropertyChanged -= Settings_PropertyChanged;
+    }
+
+    public void RenderPreview()
+    {
+        IsPreviewRendered = HasPreviewImage();
+        UpdatePreviewStatus();
+    }
+
+    void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(SettingsFile.AutomaticallyRenderImagePreviews))
+            ResetPreviewState();
+    }
+
+    void ResetPreviewState()
+    {
+        IsPreviewRendered = ShouldRenderImagePreviewsAutomatically() && HasPreviewImage();
+        UpdatePreviewStatus();
+    }
+
+    void UpdatePreviewStatus()
+    {
+        PreviewStatus = GetPreviewImage() is null
+            ? "No sprite texture loaded."
+            : IsPreviewRendered
+                ? "Sprite preview rendered."
+                : "Sprite preview not rendered.";
+    }
+
+    UndertaleTexturePageItem? GetPreviewImage()
+    {
+        return GameObject.Sprite?.Textures.Count > 0 ? GameObject.Sprite.Textures[0].Texture : null;
+    }
+
+    bool HasPreviewImage()
+    {
+        UndertaleTexturePageItem? texture = GetPreviewImage();
+        return texture?.TexturePage?.TextureData?.Image is not null;
+    }
+
+    bool ShouldRenderImagePreviewsAutomatically()
+    {
+        return MainVM.Settings?.AutomaticallyRenderImagePreviews ?? true;
     }
 
     public static UndertaleGameObject.UndertalePhysicsVertex CreatePhysicsVertex() => new();
     public static UndertaleGameObject.Event CreateEvent() => new();
     public static UndertaleGameObject.EventAction CreateEventAction() => new();
 
-    public async Task<UndertaleResource?> CreateEventActionCode(object? argument)
+    public Task<UndertaleResource?> CreateEventActionCode(object? argument)
     {
         if (argument is not IList list || list is not [EventType eventType, uint eventSubtype])
-            return null;
+            return Task.FromResult<UndertaleResource?>(null);
 
-        return GameObject?.EventHandlerFor(eventType, eventSubtype, MainVM.Data);
+        return Task.FromResult<UndertaleResource?>(GameObject?.EventHandlerFor(eventType, eventSubtype, MainVM.Data));
     }
 }

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleRoomView.axaml
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleRoomView.axaml
@@ -687,6 +687,9 @@
             <Grid Grid.Row="0" ColumnDefinitions="1*,Auto">
                 <StackPanel Grid.Column="0" Orientation="Horizontal">
                     <Button Command="{Binding SaveAsImage}">Save as image</Button>
+                    <Button Command="{Binding RenderPreview}"
+                            IsVisible="{Binding !IsPreviewRendered}">Render preview</Button>
+                    <TextBlock Text="{Binding PreviewStatus}" VerticalAlignment="Center" />
                     <TextBlock Text="{Binding StatusText}" VerticalAlignment="Center" />
                 </StackPanel>
                 <StackPanel Grid.Column="1" Orientation="Horizontal">
@@ -700,7 +703,7 @@
             </Grid>
             <!-- View -->
             <Panel Grid.Row="1">
-                <l:UndertaleRoomEditor />
+                <l:UndertaleRoomEditor IsRenderingEnabled="{Binding IsPreviewRendered}" />
             </Panel>
         </Grid>
     </Grid>

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleRoomViewModel.cs
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleRoomViewModel.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
 using Microsoft.Extensions.DependencyInjection;
@@ -52,6 +54,12 @@ public partial class UndertaleRoomViewModel : IUndertaleResourceViewModel
     private double _Zoom = 1;
 
     [Notify]
+    private bool _IsPreviewRendered;
+
+    [Notify]
+    private string _PreviewStatus = "";
+
+    [Notify]
     private uint _SelectedTileData = 0;
     [Notify]
     private uint _TileSetColumns = 0;
@@ -83,6 +91,49 @@ public partial class UndertaleRoomViewModel : IUndertaleResourceViewModel
         if (isGMS2)
             RoomTreeItems.Add(new("Layers", "Layers", Room.Layers));
 
+        ResetPreviewState();
+    }
+
+    public void OnAttached()
+    {
+        if (MainVM.Settings is not null)
+            MainVM.Settings.PropertyChanged += Settings_PropertyChanged;
+    }
+
+    public void OnDetached()
+    {
+        if (MainVM.Settings is not null)
+            MainVM.Settings.PropertyChanged -= Settings_PropertyChanged;
+    }
+
+    public void RenderPreview()
+    {
+        IsPreviewRendered = true;
+        UpdatePreviewStatus();
+    }
+
+    void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(SettingsFile.AutomaticallyRenderImagePreviews))
+            ResetPreviewState();
+    }
+
+    void ResetPreviewState()
+    {
+        IsPreviewRendered = ShouldRenderImagePreviewsAutomatically();
+        UpdatePreviewStatus();
+    }
+
+    void UpdatePreviewStatus()
+    {
+        PreviewStatus = IsPreviewRendered
+            ? "Room preview rendered."
+            : "Room preview not rendered.";
+    }
+
+    bool ShouldRenderImagePreviewsAutomatically()
+    {
+        return MainVM.Settings?.AutomaticallyRenderImagePreviews ?? true;
     }
 
     public void AddLayer(LayerType type)
@@ -342,7 +393,7 @@ public partial class UndertaleRoomViewModel : IUndertaleResourceViewModel
         return null;
     }
 
-    public async void AutoSizeTileLayer()
+    public void AutoSizeTileLayer()
     {
         if (PropertiesContent is Layer layer)
         {
@@ -381,7 +432,15 @@ public partial class UndertaleRoomViewModel : IUndertaleResourceViewModel
 
     public async void SaveAsImage()
     {
-        IStorageFile? file = await MainVM.View!.SaveFileDialog(new FilePickerSaveOptions()
+        await SaveAsImageTask();
+    }
+
+    public async Task<bool> SaveAsImageTask()
+    {
+        if (MainVM.View is not { } view)
+            return false;
+
+        IStorageFile? file = await view.SaveFileDialog(new FilePickerSaveOptions()
         {
             Title = "Save image",
             FileTypeChoices = FilePickerFileTypes.PNG,
@@ -390,12 +449,14 @@ public partial class UndertaleRoomViewModel : IUndertaleResourceViewModel
         });
 
         if (file is null)
-            return;
+            return false;
 
         using (Stream stream = await file.OpenWriteAsync())
         {
             await ImportExport.ExportRoomAsPNG(Room, stream);
         }
+
+        return true;
     }
 
     private void OnRoomTreeItemsSelectedItemChanged()

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleShaderViewModel.cs
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleShaderViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using Avalonia.Platform.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using UndertaleModLib;
@@ -35,20 +36,61 @@ public partial class UndertaleShaderViewModel : IUndertaleResourceViewModel
             "Cg_PSVita_PixelData" => Shader.Cg_PSVita_PixelData,
             "Cg_PS3_VertexData" => Shader.Cg_PS3_VertexData,
             "Cg_PS3_PixelData" => Shader.Cg_PS3_PixelData,
-            _ => throw new NotImplementedException(),
+            _ => null,
         };
+    }
+
+    bool SetRawShaderDataFromString(string parameter, UndertaleShader.UndertaleRawShaderData rawShaderData)
+    {
+        switch (parameter)
+        {
+            case "HLSL11_VertexData":
+                Shader.HLSL11_VertexData = rawShaderData;
+                return true;
+            case "HLSL11_PixelData":
+                Shader.HLSL11_PixelData = rawShaderData;
+                return true;
+            case "PSSL_VertexData":
+                Shader.PSSL_VertexData = rawShaderData;
+                return true;
+            case "PSSL_PixelData":
+                Shader.PSSL_PixelData = rawShaderData;
+                return true;
+            case "Cg_PSVita_VertexData":
+                Shader.Cg_PSVita_VertexData = rawShaderData;
+                return true;
+            case "Cg_PSVita_PixelData":
+                Shader.Cg_PSVita_PixelData = rawShaderData;
+                return true;
+            case "Cg_PS3_VertexData":
+                Shader.Cg_PS3_VertexData = rawShaderData;
+                return true;
+            case "Cg_PS3_PixelData":
+                Shader.Cg_PS3_PixelData = rawShaderData;
+                return true;
+            default:
+                return false;
+        }
     }
 
     public async void ImportRawShaderData(string parameter)
     {
-        IReadOnlyList<IStorageFile> files = await MainVM.View!.OpenFileDialog(new FilePickerOpenOptions
+        await ImportRawShaderDataTask(parameter);
+    }
+
+    public async Task<bool> ImportRawShaderDataTask(string parameter)
+    {
+        if (MainVM.View is not { } view)
+            return false;
+
+        IReadOnlyList<IStorageFile> files = await view.OpenFileDialog(new FilePickerOpenOptions
         {
             Title = "Import shader",
             FileTypeFilter = FilePickerFileTypes.BIN,
         });
 
         if (files.Count != 1)
-            return;
+            return false;
 
         using Stream stream = await files[0].OpenReadAsync();
         byte[] bytes = new byte[stream.Length];
@@ -60,33 +102,34 @@ public partial class UndertaleShaderViewModel : IUndertaleResourceViewModel
         {
             rawShaderData = new UndertaleShader.UndertaleRawShaderData();
 
-            Action setRawShaderData = parameter switch
+            if (!SetRawShaderDataFromString(parameter, rawShaderData))
             {
-                "HLSL11_VertexData" => () => Shader.HLSL11_VertexData = rawShaderData,
-                "HLSL11_PixelData" => () => Shader.HLSL11_PixelData = rawShaderData,
-                "PSSL_VertexData" => () => Shader.PSSL_VertexData = rawShaderData,
-                "PSSL_PixelData" => () => Shader.PSSL_PixelData = rawShaderData,
-                "Cg_PSVita_VertexData" => () => Shader.Cg_PSVita_VertexData = rawShaderData,
-                "Cg_PSVita_PixelData" => () => Shader.Cg_PSVita_PixelData = rawShaderData,
-                "Cg_PS3_VertexData" => () => Shader.Cg_PS3_VertexData = rawShaderData,
-                "Cg_PS3_PixelData" => () => Shader.Cg_PS3_PixelData = rawShaderData,
-                _ => throw new NotImplementedException(),
-            };
-            setRawShaderData();
+                await view.MessageDialog($"Unknown shader data target: {parameter}", title: "Import shader");
+                return false;
+            }
         }
 
         rawShaderData.IsNull = false;
         rawShaderData.Data = bytes;
+        return true;
     }
 
     public async void ExportRawShaderData(string parameter)
     {
+        await ExportRawShaderDataTask(parameter);
+    }
+
+    public async Task<bool> ExportRawShaderDataTask(string parameter)
+    {
         UndertaleShader.UndertaleRawShaderData? rawShaderData = GetRawShaderDataFromString(parameter);
 
         if (rawShaderData is null)
-            return;
+            return false;
 
-        IStorageFile? file = await MainVM.View!.SaveFileDialog(new FilePickerSaveOptions()
+        if (MainVM.View is not { } view)
+            return false;
+
+        IStorageFile? file = await view.SaveFileDialog(new FilePickerSaveOptions()
         {
             Title = "Export shader",
             FileTypeChoices = FilePickerFileTypes.BIN,
@@ -95,10 +138,11 @@ public partial class UndertaleShaderViewModel : IUndertaleResourceViewModel
         });
 
         if (file is null)
-            return;
+            return false;
 
         using Stream stream = await file.OpenWriteAsync();
 
         stream.Write(rawShaderData.Data);
+        return true;
     }
 }

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleSoundView.axaml
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleSoundView.axaml
@@ -40,6 +40,15 @@
 
                 <Label>Audio group</Label>
                 <l:UndertaleResourceReferenceView Reference="{Binding Sound.AudioGroup}" ReferenceType="undertalem:UndertaleAudioGroup" />
+
+                <Label>Audio routing</Label>
+                <TextBlock Text="{Binding AudioRoutingSummary}" TextWrapping="Wrap" />
+
+                <Label>Audio data</Label>
+                <TextBlock Text="{Binding AudioDataSummary}" TextWrapping="Wrap" />
+
+                <Label>Playback</Label>
+                <TextBlock Text="{Binding PlaybackSummary}" TextWrapping="Wrap" />
             </Grid>
 
             <StackPanel IsVisible="{Binding IsBuiltinAudioGroup}">

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleSoundViewModel.cs
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleSoundViewModel.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using PropertyChanged.SourceGenerator;
 using UndertaleModLib;
@@ -16,6 +19,15 @@ public partial class UndertaleSoundViewModel : IUndertaleResourceViewModel
     [Notify]
     private bool _IsBuiltinAudioGroup;
 
+    [Notify]
+    private string _AudioRoutingSummary = "";
+
+    [Notify]
+    private string _AudioDataSummary = "";
+
+    [Notify]
+    private string _PlaybackSummary = "";
+
     AudioPlayer? audioPlayer = null;
 
     public UndertaleSoundViewModel(UndertaleSound sound, IServiceProvider serviceProvider)
@@ -24,12 +36,13 @@ public partial class UndertaleSoundViewModel : IUndertaleResourceViewModel
 
         Sound = sound;
 
-        UpdateIsBuiltinAudioGroup();
+        RefreshAudioDetails();
     }
 
     public void OnAttached()
     {
         Sound.PropertyChanged += OnSoundPropertyChanged;
+        RefreshAudioDetails();
     }
 
     public void OnDetached()
@@ -40,12 +53,33 @@ public partial class UndertaleSoundViewModel : IUndertaleResourceViewModel
 
     public async void PlayAudio()
     {
-        audioPlayer?.Stop();
-        if (Sound.AudioFile is not null)
-            audioPlayer = new(Sound.AudioFile.Data);
+        await PlayAudioTask();
     }
 
-    public async void StopAudio()
+    public async Task<bool> PlayAudioTask()
+    {
+        StopAudio();
+
+        byte[] data = Sound.AudioFile?.Data ?? [];
+
+        if (data.Length == 0)
+            return false;
+
+        try
+        {
+            audioPlayer = new(data);
+            return true;
+        }
+        catch (Exception e)
+        {
+            if (MainVM.View is not null)
+                await MainVM.View.MessageDialog($"Failed to play audio: {e.Message}");
+
+            return false;
+        }
+    }
+
+    public void StopAudio()
     {
         audioPlayer?.Stop();
         audioPlayer = null;
@@ -53,14 +87,103 @@ public partial class UndertaleSoundViewModel : IUndertaleResourceViewModel
 
     void OnSoundPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(UndertaleSound.AudioGroup))
+        if (e.PropertyName == nameof(UndertaleSound.AudioGroup) ||
+            e.PropertyName == nameof(UndertaleSound.AudioFile) ||
+            e.PropertyName == nameof(UndertaleSound.AudioID) ||
+            e.PropertyName == nameof(UndertaleSound.GroupID))
         {
-            UpdateIsBuiltinAudioGroup();
+            RefreshAudioDetails();
         }
     }
 
     void UpdateIsBuiltinAudioGroup()
     {
-        IsBuiltinAudioGroup = Sound.AudioGroup is null || (MainVM.Data!.AudioGroups.IndexOf(Sound.AudioGroup) == MainVM.Data!.GetBuiltinSoundGroupID());
+        UndertaleData? data = MainVM.Data;
+        int groupIndex = GetAudioGroupIndex();
+        int builtinGroupId = data?.GetBuiltinSoundGroupID() ?? 0;
+
+        IsBuiltinAudioGroup = Sound.AudioGroup is null || groupIndex == builtinGroupId || Sound.GroupID == builtinGroupId;
+    }
+
+    void RefreshAudioDetails()
+    {
+        UpdateIsBuiltinAudioGroup();
+
+        AudioRoutingSummary = GetAudioRoutingSummary();
+        AudioDataSummary = GetAudioDataSummary();
+        PlaybackSummary = GetPlaybackSummary();
+    }
+
+    string GetAudioRoutingSummary()
+    {
+        UndertaleAudioGroup? group = Sound.AudioGroup;
+        int groupIndex = GetAudioGroupIndex();
+        string groupName = group?.Name?.Content ?? "(none)";
+        string groupIdText = groupIndex >= 0 ? $"group #{groupIndex}" : $"group id {Sound.GroupID}";
+
+        if (IsBuiltinAudioGroup)
+            return $"{groupIdText} {groupName}; uses embedded audio stored in the data file.";
+
+        string path = group?.Path?.Content ?? "";
+        string pathText = string.IsNullOrWhiteSpace(path) ? "" : $" Path: {path}.";
+
+        return $"{groupIdText} {groupName}; audio id {Sound.AudioID} inside the group file.{pathText}";
+    }
+
+    string GetAudioDataSummary()
+    {
+        if (IsBuiltinAudioGroup)
+            return AudioMetadata.DescribeEmbeddedAudio(Sound.AudioFile, MainVM.Data);
+
+        return $"External audio group entry id {Sound.AudioID}. Import/export is handled through the audio group data.";
+    }
+
+    string GetPlaybackSummary()
+    {
+        List<string> parts =
+        [
+            $"flags {DescribeFlags(Sound.Flags)}",
+            $"volume {Sound.Volume.ToString("0.###", CultureInfo.InvariantCulture)}",
+            $"pitch {Sound.Pitch.ToString("0.###", CultureInfo.InvariantCulture)}",
+            $"preload {Sound.Preload}",
+            $"effects {Sound.Effects}",
+        ];
+
+        if (Sound.AudioLength > 0)
+            parts.Add($"length {Sound.AudioLength} us");
+
+        return string.Join("; ", parts) + ".";
+    }
+
+    int GetAudioGroupIndex()
+    {
+        if (MainVM.Data?.AudioGroups is null || Sound.AudioGroup is null)
+            return -1;
+
+        return MainVM.Data.AudioGroups.IndexOf(Sound.AudioGroup);
+    }
+
+    static string DescribeFlags(UndertaleSound.AudioEntryFlags flags)
+    {
+        List<string> parts = [];
+
+        if ((flags & UndertaleSound.AudioEntryFlags.IsEmbedded) != 0)
+            parts.Add("embedded");
+
+        if ((flags & UndertaleSound.AudioEntryFlags.IsCompressed) != 0)
+            parts.Add("compressed");
+
+        if ((flags & UndertaleSound.AudioEntryFlags.IsDecompressedOnLoad) == UndertaleSound.AudioEntryFlags.IsDecompressedOnLoad)
+            parts.Add("decompress on load");
+
+        if ((flags & UndertaleSound.AudioEntryFlags.Regular) == UndertaleSound.AudioEntryFlags.Regular)
+            parts.Add("regular");
+
+        string rawValue = ((uint)flags).ToString(CultureInfo.InvariantCulture);
+
+        if (parts.Count == 0)
+            return $"{flags} ({rawValue})";
+
+        return $"{flags} ({rawValue}, {string.Join(", ", parts)})";
     }
 }

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleSpriteView.axaml
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleSpriteView.axaml
@@ -68,10 +68,17 @@
                     </l:EditableDataGrid.Columns>
                 </l:EditableDataGrid>
             </Grid>
-            
+
+            <Grid ColumnDefinitions="*,Auto">
+                <TextBlock Text="{Binding TexturePreviewStatus}" VerticalAlignment="Center" />
+                <Button Grid.Column="1"
+                        Command="{Binding RenderTexturePreview}"
+                        IsVisible="{Binding !IsTexturePreviewRendered}">Render preview</Button>
+            </Grid>
             <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" HorizontalAlignment="Center"
                           MaxHeight="{Binding $parent[ScrollViewer].Viewport.Height}">
-                <l:SKImageViewer Image="{Binding TexturesSelected.Texture}" />
+                <l:SKImageViewer Image="{Binding TexturesSelected.Texture}"
+                                 IsRenderingEnabled="{Binding IsTexturePreviewRendered}" />
             </ScrollViewer>
 
             <StackPanel Orientation="Horizontal">
@@ -95,9 +102,16 @@
             </Grid>
 
             <StackPanel IsVisible="{Binding CollisionMasksSelected, Converter={x:Static ObjectConverters.IsNotNull}}">
+                <Grid ColumnDefinitions="*,Auto">
+                    <TextBlock Text="{Binding CollisionMaskPreviewStatus}" VerticalAlignment="Center" />
+                    <Button Grid.Column="1"
+                            Command="{Binding RenderCollisionMaskPreview}"
+                            IsVisible="{Binding !IsCollisionMaskPreviewRendered}">Render preview</Button>
+                </Grid>
                 <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" HorizontalAlignment="Center"
                               MaxHeight="{Binding $parent[ScrollViewer].Viewport.Height}">
-                    <l:SKImageViewer Image="{Binding CollisionMasksSelected}" />
+                    <l:SKImageViewer Image="{Binding CollisionMasksSelected}"
+                                     IsRenderingEnabled="{Binding IsCollisionMaskPreviewRendered}" />
                 </ScrollViewer>
 
                 <StackPanel Orientation="Horizontal">

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleSpriteViewModel.cs
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleSpriteViewModel.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
+using System.Threading.Tasks;
 using Avalonia.Platform.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using PropertyChanged.SourceGenerator;
@@ -20,6 +22,15 @@ public partial class UndertaleSpriteViewModel : IUndertaleResourceViewModel
     [Notify]
     private UndertaleSprite.MaskEntry? _CollisionMasksSelected;
 
+    [Notify]
+    private bool _IsTexturePreviewRendered;
+    [Notify]
+    private bool _IsCollisionMaskPreviewRendered;
+    [Notify]
+    private string _TexturePreviewStatus = "";
+    [Notify]
+    private string _CollisionMaskPreviewStatus = "";
+
     public UndertaleSpriteViewModel(UndertaleSprite sprite, IServiceProvider serviceProvider)
     {
         MainVM = serviceProvider.GetRequiredService<MainViewModel>();
@@ -30,6 +41,21 @@ public partial class UndertaleSpriteViewModel : IUndertaleResourceViewModel
             TexturesSelected = Sprite.Textures[0];
         if (Sprite.CollisionMasks.Count > 0)
             CollisionMasksSelected = Sprite.CollisionMasks[0];
+
+        ResetTexturePreviewState();
+        ResetCollisionMaskPreviewState();
+    }
+
+    public void OnAttached()
+    {
+        if (MainVM.Settings is not null)
+            MainVM.Settings.PropertyChanged += Settings_PropertyChanged;
+    }
+
+    public void OnDetached()
+    {
+        if (MainVM.Settings is not null)
+            MainVM.Settings.PropertyChanged -= Settings_PropertyChanged;
     }
 
     public void TexturesSelectedChanged(object? item)
@@ -43,7 +69,10 @@ public partial class UndertaleSpriteViewModel : IUndertaleResourceViewModel
         }
         else
             TexturesSelected = (UndertaleSprite.TextureEntry?)item!;
+
+        ResetTexturePreviewState();
     }
+
     public void CollisionMasksSelectedChanged(object? item)
     {
         if (item is null)
@@ -55,19 +84,85 @@ public partial class UndertaleSpriteViewModel : IUndertaleResourceViewModel
         }
         else
             CollisionMasksSelected = (UndertaleSprite.MaskEntry?)item!;
+
+        ResetCollisionMaskPreviewState();
+    }
+
+    public void RenderTexturePreview()
+    {
+        IsTexturePreviewRendered = TexturesSelected?.Texture is not null;
+        UpdateTexturePreviewStatus();
+    }
+
+    public void RenderCollisionMaskPreview()
+    {
+        IsCollisionMaskPreviewRendered = CollisionMasksSelected is not null;
+        UpdateCollisionMaskPreviewStatus();
+    }
+
+    void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(SettingsFile.AutomaticallyRenderImagePreviews))
+        {
+            ResetTexturePreviewState();
+            ResetCollisionMaskPreviewState();
+        }
+    }
+
+    void ResetTexturePreviewState()
+    {
+        IsTexturePreviewRendered = ShouldRenderImagePreviewsAutomatically() && TexturesSelected?.Texture is not null;
+        UpdateTexturePreviewStatus();
+    }
+
+    void ResetCollisionMaskPreviewState()
+    {
+        IsCollisionMaskPreviewRendered = ShouldRenderImagePreviewsAutomatically() && CollisionMasksSelected is not null;
+        UpdateCollisionMaskPreviewStatus();
+    }
+
+    void UpdateTexturePreviewStatus()
+    {
+        TexturePreviewStatus = TexturesSelected?.Texture is null
+            ? "No texture frame selected."
+            : IsTexturePreviewRendered
+                ? "Texture preview rendered."
+                : "Texture preview not rendered.";
+    }
+
+    void UpdateCollisionMaskPreviewStatus()
+    {
+        CollisionMaskPreviewStatus = CollisionMasksSelected is null
+            ? "No collision mask selected."
+            : IsCollisionMaskPreviewRendered
+                ? "Collision mask preview rendered."
+                : "Collision mask preview not rendered.";
+    }
+
+    bool ShouldRenderImagePreviewsAutomatically()
+    {
+        return MainVM.Settings?.AutomaticallyRenderImagePreviews ?? true;
     }
 
     public async void ExportAllTexturesAsPNGs()
     {
+        await ExportAllTexturesAsPNGsTask();
+    }
+
+    public async Task<bool> ExportAllTexturesAsPNGsTask()
+    {
+        if (MainVM.View is not { } view)
+            return false;
+
         string GetFileNameOfTexture(int i) => $"{Sprite.Name.Content}_{i}.png";
 
-        IReadOnlyList<IStorageFolder> folders = await MainVM.View!.OpenFolderDialog(new FolderPickerOpenOptions()
+        IReadOnlyList<IStorageFolder> folders = await view.OpenFolderDialog(new FolderPickerOpenOptions()
         {
             Title = "Export all textures into folder",
         });
 
         if (folders.Count != 1)
-            return;
+            return false;
 
         IStorageFolder folder = folders[0];
 
@@ -83,11 +178,11 @@ public partial class UndertaleSpriteViewModel : IUndertaleResourceViewModel
 
         if (filesThatAlreadyExist.Count > 0)
         {
-            MessageWindow.Result result = await MainVM.View!.MessageDialog($"The following files already exist. Do you want to replace them?"
+            MessageWindow.Result result = await view.MessageDialog($"The following files already exist. Do you want to replace them?"
                 + $"\n\n{string.Join("\n", filesThatAlreadyExist)}", buttons: MessageWindow.Buttons.YesCancel);
 
             if (result != MessageWindow.Result.Yes)
-                return;
+                return false;
         }
 
         for (int i = 0; i < Sprite.Textures.Count; i++)
@@ -98,8 +193,8 @@ public partial class UndertaleSpriteViewModel : IUndertaleResourceViewModel
             IStorageFile? file = await folder.CreateFileAsync(fileName);
             if (file is null)
             {
-                await MainVM.View!.MessageDialog($"Error: Could not create file \"{fileName}\"");
-                return;
+                await view.MessageDialog($"Error: Could not create file \"{fileName}\"");
+                return false;
             }
 
             using (var stream = await file.OpenWriteAsync())
@@ -107,34 +202,54 @@ public partial class UndertaleSpriteViewModel : IUndertaleResourceViewModel
                 await ImportExport.ExportTexturePageItemAsPNG(texture, stream, MainVM);
             }
         }
+
+        return true;
     }
 
     public async void ImportCollisionMaskData()
     {
-        if (CollisionMasksSelected is null)
-            return;
+        await ImportCollisionMaskDataTask();
+    }
 
-        IReadOnlyList<IStorageFile> files = await MainVM.View!.OpenFileDialog(new FilePickerOpenOptions
+    public async Task<bool> ImportCollisionMaskDataTask()
+    {
+        if (CollisionMasksSelected is null)
+            return false;
+
+        if (MainVM.View is not { } view)
+            return false;
+
+        IReadOnlyList<IStorageFile> files = await view.OpenFileDialog(new FilePickerOpenOptions
         {
             Title = "Import collision mask data",
             FileTypeFilter = FilePickerFileTypes.BIN,
         });
 
         if (files.Count != 1)
-            return;
+            return false;
 
         using (Stream stream = await files[0].OpenReadAsync())
         {
             await ImportExport.ImportSpriteCollisionMaskData(Sprite, Sprite.CollisionMasks.IndexOf(CollisionMasksSelected), stream, MainVM);
         }
+
+        return true;
     }
 
     public async void ExportCollisionMaskData()
     {
-        if (CollisionMasksSelected is null)
-            return;
+        await ExportCollisionMaskDataTask();
+    }
 
-        IStorageFile? file = await MainVM.View!.SaveFileDialog(new FilePickerSaveOptions()
+    public async Task<bool> ExportCollisionMaskDataTask()
+    {
+        if (CollisionMasksSelected is null)
+            return false;
+
+        if (MainVM.View is not { } view)
+            return false;
+
+        IStorageFile? file = await view.SaveFileDialog(new FilePickerSaveOptions()
         {
             Title = "Export collision mask data",
             FileTypeChoices = FilePickerFileTypes.BIN,
@@ -142,12 +257,14 @@ public partial class UndertaleSpriteViewModel : IUndertaleResourceViewModel
         });
 
         if (file is null)
-            return;
+            return false;
 
         using (Stream stream = await file.OpenWriteAsync())
         {
             await ImportExport.ExportSpriteCollisionMaskData(Sprite, Sprite.CollisionMasks.IndexOf(CollisionMasksSelected), stream);
         }
+
+        return true;
     }
 
     public static UndertaleSprite.TextureEntry CreateTextureEntry() => new();

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleTexturePageItemView.axaml
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleTexturePageItemView.axaml
@@ -7,6 +7,10 @@
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="UndertaleModToolAvalonia.UndertaleTexturePageItemView"
              x:DataType="l:UndertaleTexturePageItemViewModel">
+    <UserControl.Resources>
+        <l:ZoomConverter x:Key="ZoomConverter" />
+    </UserControl.Resources>
+
     <ScrollViewer>
         <StackPanel>
             <Grid l:AutoGridBehavior.Enable="True" ColumnDefinitions="1*,3*" Classes="PaddedProperties">
@@ -37,16 +41,41 @@
             </Grid>
 
             <StackPanel Orientation="Horizontal">
-                <Button Command="{Binding SaveImage}">Save image</Button>
+                <Button Command="{Binding ImportImage}"
+                        IsEnabled="{Binding TexturePageItem.TexturePage, Converter={x:Static ObjectConverters.IsNotNull}}">
+                    Import PNG
+                </Button>
+                <Button Command="{Binding ExportImage}"
+                        IsEnabled="{Binding TexturePageItem.TexturePage, Converter={x:Static ObjectConverters.IsNotNull}}">
+                    Export PNG
+                </Button>
+                <Button Command="{Binding OpenTexturePage}"
+                        IsEnabled="{Binding TexturePageItem.TexturePage, Converter={x:Static ObjectConverters.IsNotNull}}">
+                    Open texture page
+                </Button>
+                <Button Command="{Binding OpenTexturePageInNewTab}"
+                        IsEnabled="{Binding TexturePageItem.TexturePage, Converter={x:Static ObjectConverters.IsNotNull}}">
+                    Open texture page in new tab
+                </Button>
+                <TextBlock Text="Zoom" VerticalAlignment="Center" Margin="12,0,4,0" />
+                <Button Command="{Binding ZoomOut}">-</Button>
+                <TextBox Text="{Binding PreviewZoom, Converter={StaticResource ZoomConverter}}" Width="70" />
+                <Button Command="{Binding ZoomIn}">+</Button>
+                <Button Command="{Binding ZoomReset}">100%</Button>
             </StackPanel>
 
+            <Grid ColumnDefinitions="*,Auto" Classes="PaddedProperties">
+                <TextBlock Text="{Binding PreviewStatus}" VerticalAlignment="Center" />
+                <Button Grid.Column="1"
+                        Command="{Binding RenderPreview}"
+                        IsVisible="{Binding !IsPreviewRendered}">Render preview</Button>
+            </Grid>
             <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto" HorizontalAlignment="Center"
                           MaxHeight="{Binding $parent[ScrollViewer].Viewport.Height}">
-                <l:SKImageViewer Image="{Binding TexturePageItem}" />
+                <l:SKImageViewer Image="{Binding TexturePageItem}"
+                                 Zoom="{Binding PreviewZoom, Mode=TwoWay}"
+                                 IsRenderingEnabled="{Binding IsPreviewRendered}" />
             </ScrollViewer>
-
-            <!-- TODO: Import/Export -->
-            <!-- TODO: Show item in texture -->
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/UndertaleModToolAvalonia/ResourceViews/UndertaleTexturePageItemViewModel.cs
+++ b/UndertaleModToolAvalonia/ResourceViews/UndertaleTexturePageItemViewModel.cs
@@ -1,9 +1,14 @@
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
+using System.Threading.Tasks;
 using Avalonia.Platform.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using PropertyChanged.SourceGenerator;
 using UndertaleModLib;
 using UndertaleModLib.Models;
+using UndertaleModLib.Util;
 
 namespace UndertaleModToolAvalonia;
 
@@ -13,28 +18,184 @@ public partial class UndertaleTexturePageItemViewModel : IUndertaleResourceViewM
     public UndertaleResource Resource => TexturePageItem;
     public UndertaleTexturePageItem TexturePageItem { get; }
 
+    [Notify]
+    private double _PreviewZoom = 1;
+
+    [Notify]
+    private bool _IsPreviewRendered;
+
+    [Notify]
+    private string _PreviewStatus = "";
+
     public UndertaleTexturePageItemViewModel(UndertaleTexturePageItem texturePageItem, IServiceProvider serviceProvider)
     {
         MainVM = serviceProvider.GetRequiredService<MainViewModel>();
 
         TexturePageItem = texturePageItem;
+        ResetPreviewState();
     }
 
-    public async void SaveImage()
+    public void OnAttached()
     {
-        IStorageFile? file = await MainVM.View!.SaveFileDialog(new FilePickerSaveOptions()
+        if (MainVM.Settings is not null)
+            MainVM.Settings.PropertyChanged += Settings_PropertyChanged;
+    }
+
+    public void OnDetached()
+    {
+        if (MainVM.Settings is not null)
+            MainVM.Settings.PropertyChanged -= Settings_PropertyChanged;
+    }
+
+    public void ZoomIn()
+    {
+        PreviewZoom = Math.Min(32, PreviewZoom * 2);
+    }
+
+    public void ZoomOut()
+    {
+        PreviewZoom = Math.Max(0.125, PreviewZoom / 2);
+    }
+
+    public void ZoomReset()
+    {
+        PreviewZoom = 1;
+    }
+
+    public void OpenTexturePage()
+    {
+        OpenTexturePage(inNewTab: false);
+    }
+
+    public void OpenTexturePageInNewTab()
+    {
+        OpenTexturePage(inNewTab: true);
+    }
+
+    void OpenTexturePage(bool inNewTab)
+    {
+        if (TexturePageItem.TexturePage is null)
+            return;
+
+        TabItemViewModel? tab = MainVM.TabOpen(TexturePageItem.TexturePage, inNewTab);
+        if (tab?.Content is UndertaleEmbeddedTextureViewModel textureViewModel)
+            textureViewModel.SelectedTexturePageItem = TexturePageItem;
+    }
+
+    private void OnPreviewZoomChanged()
+    {
+        if (double.IsNaN(PreviewZoom) || double.IsInfinity(PreviewZoom))
         {
-            Title = "Save image",
+            PreviewZoom = 1;
+            return;
+        }
+
+        PreviewZoom = Math.Clamp(PreviewZoom, 0.125, 32);
+    }
+
+    public void RenderPreview()
+    {
+        IsPreviewRendered = TexturePageItem.TexturePage?.TextureData?.Image is not null;
+        UpdatePreviewStatus();
+    }
+
+    void Settings_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(SettingsFile.AutomaticallyRenderImagePreviews))
+            ResetPreviewState();
+    }
+
+    void ResetPreviewState()
+    {
+        IsPreviewRendered = ShouldRenderImagePreviewsAutomatically() && TexturePageItem.TexturePage?.TextureData?.Image is not null;
+        UpdatePreviewStatus();
+    }
+
+    void UpdatePreviewStatus()
+    {
+        PreviewStatus = TexturePageItem.TexturePage?.TextureData?.Image is null
+            ? "No texture image loaded."
+            : IsPreviewRendered
+                ? "Texture page item preview rendered."
+                : "Texture page item preview not rendered.";
+    }
+
+    bool ShouldRenderImagePreviewsAutomatically()
+    {
+        return MainVM.Settings?.AutomaticallyRenderImagePreviews ?? true;
+    }
+
+    public async void ImportImage()
+    {
+        await ImportImageTask();
+    }
+
+    public async Task<bool> ImportImageTask()
+    {
+        if (MainVM.View is not { } view)
+            return false;
+
+        IReadOnlyList<IStorageFile> files = await view.OpenFileDialog(new FilePickerOpenOptions
+        {
+            Title = "Import PNG",
+            FileTypeFilter = FilePickerFileTypes.PNG,
+        });
+
+        if (files.Count != 1)
+            return false;
+
+        try
+        {
+            GMImage.ImageFormat previousFormat = TexturePageItem.TexturePage.TextureData.Image.Format;
+
+            using (Stream stream = await files[0].OpenReadAsync())
+            {
+                await ImportExport.ImportTexturePageItemAsPNG(TexturePageItem, stream);
+            }
+
+            GMImage.ImageFormat currentFormat = TexturePageItem.TexturePage.TextureData.Image.Format;
+            if (previousFormat == GMImage.ImageFormat.Dds && currentFormat == GMImage.ImageFormat.Png)
+            {
+                await view.MessageDialog(
+                    $"{TexturePageItem.TexturePage} was converted into PNG format because DDS texture writing is not supported.",
+                    "Texture converted");
+            }
+
+            ResetPreviewState();
+            return true;
+        }
+        catch (Exception e)
+        {
+            await view.MessageDialog(e.Message, "Failed to import image");
+            return false;
+        }
+    }
+
+    public async void ExportImage()
+    {
+        await ExportImageTask();
+    }
+
+    public async Task<bool> ExportImageTask()
+    {
+        if (MainVM.View is not { } view)
+            return false;
+
+        IStorageFile? file = await view.SaveFileDialog(new FilePickerSaveOptions()
+        {
+            Title = "Export PNG",
             FileTypeChoices = FilePickerFileTypes.PNG,
             DefaultExtension = ".png",
         });
 
         if (file is null)
-            return;
+            return false;
 
         using (Stream stream = await file.OpenWriteAsync())
         {
             await ImportExport.ExportTexturePageItemAsPNG(TexturePageItem, stream, MainVM);
         }
+
+        return true;
     }
 }

--- a/UndertaleModToolAvalonia/Styles.axaml
+++ b/UndertaleModToolAvalonia/Styles.axaml
@@ -92,6 +92,15 @@
     </Style>
     <Style Selector="ScrollBar">
         <Setter Property="AllowAutoHide" Value="False"/>
+        <Setter Property="Background" Value="Transparent"/>
+        <Setter Property="MinWidth" Value="12"/>
+        <Setter Property="MinHeight" Value="12"/>
+    </Style>
+    <Style Selector="ScrollBar:vertical">
+        <Setter Property="Width" Value="12"/>
+    </Style>
+    <Style Selector="ScrollBar:horizontal">
+        <Setter Property="Height" Value="12"/>
     </Style>
     <Style Selector=":is(Control)">
         <Setter Property="ScrollViewer.AllowAutoHide" Value="False"/>

--- a/UndertaleModToolAvalonia/UndertaleModToolAvalonia.csproj
+++ b/UndertaleModToolAvalonia/UndertaleModToolAvalonia.csproj
@@ -20,6 +20,14 @@
     </ItemGroup>
 
     <ItemGroup>
+        <Content Include="..\UndertaleModTool\Scripts\**">
+            <Link>Scripts\%(RecursiveDir)%(Filename)%(Extension)</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+        </Content>
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Avalonia" Version="12.0.3" />
         <PackageReference Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
         <PackageReference Include="Avalonia.Controls.ColorPicker" Version="12.0.3" />

--- a/UndertaleModToolAvalonia/Windows/MainView.axaml
+++ b/UndertaleModToolAvalonia/Windows/MainView.axaml
@@ -43,10 +43,16 @@
     <DockPanel>
         <NativeMenuBar DockPanel.Dock="Top" />
         
-        <Grid DockPanel.Dock="Bottom" ColumnDefinitions="*,Auto,Auto">
-            <TextBox Grid.Column="0" Name="CommandTextBox" Text="{Binding CommandTextBoxText}" AcceptsReturn="True" />
-            <CheckBox Grid.Column="1" Content="Marked for export" IsChecked="{Binding TabIsMarkedForExport}" IsEnabled="{Binding TabCanMarkedForExport}" />
-            <Label Grid.Column="2" Content="{Binding TabSelectedResourceIdString}" MinWidth="100" HorizontalContentAlignment="Right"
+        <Grid DockPanel.Dock="Bottom" ColumnDefinitions="*,Auto,Auto,Auto">
+            <TextBox Grid.Column="0"
+                     Name="CommandTextBox"
+                     Text="{Binding CommandTextBoxText}"
+                     AcceptsReturn="False"
+                     TextWrapping="NoWrap"
+                     PlaceholderText="Run C# script command" />
+            <Button Grid.Column="1" Command="{Binding RunCommandText}">Run</Button>
+            <CheckBox Grid.Column="2" Content="Marked for export" IsChecked="{Binding TabIsMarkedForExport}" IsEnabled="{Binding TabCanMarkedForExport}" />
+            <Label Grid.Column="3" Content="{Binding TabSelectedResourceIdString}" MinWidth="100" HorizontalContentAlignment="Right"
                    ToolTip.Tip="This is an ID (index) of the currently open asset, item, or object. It starts from 0."/>
         </Grid>
         

--- a/UndertaleModToolAvalonia/Windows/MainView.axaml.cs
+++ b/UndertaleModToolAvalonia/Windows/MainView.axaml.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -95,7 +96,7 @@ public partial class MainView : UserControl, IView
 
     public async Task OpenSettingsDialog(IServiceProvider serviceProvider)
     {
-        Window window = this.FindLogicalAncestorOfType<Window>() ?? throw new InvalidOperationException();
+        Window window = this.RequireWindow(nameof(OpenSettingsDialog));
         await new SettingsWindow()
         {
             DataContext = new SettingsViewModel(serviceProvider),
@@ -112,7 +113,7 @@ public partial class MainView : UserControl, IView
 
     public void OpenProjectAssets(IServiceProvider serviceProvider)
     {
-        Window window = this.FindLogicalAncestorOfType<Window>() ?? throw new InvalidOperationException();
+        Window window = this.RequireWindow(nameof(OpenProjectAssets));
 
         if (projectAssetsWindow is not null)
         {
@@ -187,7 +188,9 @@ public partial class MainView : UserControl, IView
 
         if (foundIndex is IndexPath index)
         {
-            var source = (MainTreeDataGrid.Source as HierarchicalTreeDataGridSource<MainViewModel.TreeDataGridItem>)!;
+            if (MainTreeDataGrid.Source is not HierarchicalTreeDataGridSource<MainViewModel.TreeDataGridItem> source)
+                return;
+
             source.Expand(index);
         }
     }
@@ -201,13 +204,23 @@ public partial class MainView : UserControl, IView
 
         if (foundIndex is IndexPath index)
         {
-            var source = (MainTreeDataGrid.Source as HierarchicalTreeDataGridSource<MainViewModel.TreeDataGridItem>)!;
+            if (MainTreeDataGrid.Source is not HierarchicalTreeDataGridSource<MainViewModel.TreeDataGridItem> source ||
+                MainTreeDataGrid.RowSelection is null ||
+                MainTreeDataGrid.Rows is null)
+                return;
+
             source.Expand(index);
 
-            MainTreeDataGrid.RowSelection!.SelectedIndex = index;
+            MainTreeDataGrid.RowSelection.SelectedIndex = index;
 
-            int rowIndex = MainTreeDataGrid.Rows!.ModelIndexToRowIndex(index);
-            MainTreeDataGrid.RowsPresenter!.BringIntoView(rowIndex);
+            int rowIndex = MainTreeDataGrid.Rows.ModelIndexToRowIndex(index);
+            bool isVisible = MainTreeDataGrid.RowsPresenter?
+                .GetVisualDescendants()
+                .OfType<TreeDataGridRow>()
+                .Any(row => row.RowIndex == rowIndex) ?? false;
+
+            if (!isVisible && MainTreeDataGrid.RowsPresenter is { } rowsPresenter)
+                rowsPresenter.BringIntoView(rowIndex);
         }
     }
 
@@ -262,7 +275,7 @@ public partial class MainView : UserControl, IView
             if (item is not null && vm.Data is not null)
             {
                 // This could probably be better
-                IList list = (item.Value switch
+                IList? list = item.Value switch
                 {
                     "AudioGroups" => vm.Data.AudioGroups as IList,
                     "Sounds" => vm.Data.Sounds as IList,
@@ -290,9 +303,10 @@ public partial class MainView : UserControl, IView
                     "ParticleSystems" => vm.Data.ParticleSystems as IList,
                     "ParticleSystemEmitters" => vm.Data.ParticleSystemEmitters as IList,
                     _ => null,
-                })!;
+                };
 
-                vm.DataItemAdd(list);
+                if (list is not null)
+                    vm.DataItemAdd(list);
             }
         }
     }
@@ -337,8 +351,8 @@ public partial class MainView : UserControl, IView
 
                 if (name is not null)
                 {
-                    TopLevel topLevel = TopLevel.GetTopLevel(this)!;
-                    await topLevel.Clipboard!.SetTextAsync(name);
+                    if (TopLevel.GetTopLevel(this)?.Clipboard is { } clipboard)
+                        await clipboard.SetTextAsync(name);
                 }
             }
         }
@@ -351,7 +365,9 @@ public partial class MainView : UserControl, IView
             MainViewModel.TreeDataGridItem? item = GetItemFromTreeDataGridControl(e.Source);
             if (item is not null && vm.Data is not null && vm.View is not null)
             {
-                UndertaleResource resource = (item.Value as UndertaleResource)!;
+                if (item.Value is not UndertaleResource resource)
+                    return;
+
                 IList list = vm.Data[resource.GetType()];
                 int oldIndex = list.IndexOf(resource);
 
@@ -377,15 +393,15 @@ public partial class MainView : UserControl, IView
         }
     }
 
-    public async void ContextMenu_Remove_Click(object? sender, RoutedEventArgs e)
+    public void ContextMenu_Remove_Click(object? sender, RoutedEventArgs e)
     {
         if (DataContext is MainViewModel vm)
         {
             MainViewModel.TreeDataGridItem? item = GetItemFromTreeDataGridControl(e.Source);
             if (item is not null && vm.Data is not null)
             {
-                UndertaleResource resource = (item.Value as UndertaleResource)!;
-                vm.DataItemRemove(resource);
+                if (item.Value is UndertaleResource resource)
+                    vm.DataItemRemove(resource);
             }
         }
     }
@@ -471,8 +487,7 @@ public partial class MainView : UserControl, IView
             if (e.Key == Key.Enter && !e.KeyModifiers.HasFlag(KeyModifiers.Shift))
             {
                 e.Handled = true;
-                object? result = await vm.Scripting.RunScript(vm.CommandTextBoxText);
-                vm.CommandTextBoxText = result?.ToString() ?? "";
+                await vm.RunCommandTextAsync();
             }
     }
 }

--- a/UndertaleModToolAvalonia/Windows/MainViewModel.cs
+++ b/UndertaleModToolAvalonia/Windows/MainViewModel.cs
@@ -99,6 +99,26 @@ public partial class MainViewModel
     [Notify]
     private string _CommandTextBoxText = "";
 
+    public async void RunCommandText()
+    {
+        await RunCommandTextAsync();
+    }
+
+    public async Task RunCommandTextAsync()
+    {
+        string text = CommandTextBoxText.Trim('\r', '\n');
+        if (String.IsNullOrWhiteSpace(text))
+            return;
+
+        object? result = await Scripting.RunScript(text);
+        if (!Scripting.ConsumeFinishedMessageEnabled())
+            return;
+
+        CommandTextBoxText = Scripting.ScriptExecutionSuccess
+            ? result?.ToString() ?? ""
+            : Scripting.ScriptErrorMessage;
+    }
+
     // Image cache
     public ImageCache ImageCache = new();
 
@@ -109,7 +129,7 @@ public partial class MainViewModel
     {
         ServiceProvider = serviceProvider;
 
-        AudioPlayer.Init(f => Dispatcher.UIThread.Post(f));
+        AudioPlayer.Configure(f => Dispatcher.UIThread.Post(f));
 
         Tabs = [
             new TabItemViewModel(new DescriptionViewModel(
@@ -129,9 +149,17 @@ public partial class MainViewModel
 
     public async void OnLoaded()
     {
+        await OnLoadedTask();
+    }
+
+    public async Task<bool> OnLoadedTask()
+    {
+        if (View is null)
+            return false;
+
         foreach (string message in LazyErrorMessages)
         {
-            await View!.MessageDialog(message);
+            await View.MessageDialog(message);
         }
         LazyErrorMessages.Clear();
 
@@ -149,26 +177,33 @@ public partial class MainViewModel
                 }
                 catch (SystemException e)
                 {
-                    await View!.MessageDialog($"Error opening data file from argument: {e.Message}");
+                    await View.MessageDialog($"Error opening data file from argument: {e.Message}");
                 }
             }
         }
+
+        return true;
     }
 
     public async void OpenDroppedFiles(IEnumerable<IStorageItem>? files)
     {
+        await OpenDroppedFilesTask(files);
+    }
+
+    public async Task<bool> OpenDroppedFilesTask(IEnumerable<IStorageItem>? files)
+    {
         if (files is null)
-            return;
+            return false;
 
         var list = files.ToList();
         if (list.Count != 1)
-            return;
+            return false;
 
         if (list[0] is not IStorageFile file)
-            return;
+            return false;
 
         if (!await AskFileSave("Save data file before opening a new one?"))
-            return;
+            return false;
 
         CloseData();
 
@@ -177,7 +212,10 @@ public partial class MainViewModel
         if (await LoadData(stream))
         {
             DataPath = file.TryGetLocalPath();
+            return true;
         }
+
+        return false;
     }
 
     // Called by [Notify]
@@ -341,8 +379,10 @@ public partial class MainViewModel
     {
         if (Data is null)
             return true;
+        if (View is null)
+            return false;
 
-        var result = await View!.MessageDialog(message, buttons: MessageWindow.Buttons.YesNoCancel);
+        var result = await View.MessageDialog(message, buttons: MessageWindow.Buttons.YesNoCancel);
         if (result == MessageWindow.Result.Yes)
         {
             if (await FileSaveTask())
@@ -364,8 +404,10 @@ public partial class MainViewModel
     {
         if (Project is null || !Project.HasUnexportedAssets)
             return true;
+        if (View is null)
+            return false;
 
-        var result = await View!.MessageDialog(message, buttons: MessageWindow.Buttons.YesNoCancel);
+        var result = await View.MessageDialog(message, buttons: MessageWindow.Buttons.YesNoCancel);
         if (result == MessageWindow.Result.Yes)
         {
             if (await ProjectSaveTask())
@@ -393,9 +435,12 @@ public partial class MainViewModel
 
     public async Task<bool> LoadData(Stream stream)
     {
+        if (View is not { } view)
+            return false;
+
         IsEnabled = false;
 
-        ILoaderWindow w = View!.LoaderOpen();
+        ILoaderWindow w = view.LoaderOpen();
         w.SetText("Opening data file...");
 
         try
@@ -421,7 +466,7 @@ public partial class MainViewModel
             if (warnings.Count > 0)
             {
                 w.EnsureShown();
-                await View!.MessageDialog($"Warnings occurred when loading the data file:\n\n" +
+                await view.MessageDialog($"Warnings occurred when loading the data file:\n\n" +
                     $"{(hadImportantWarnings ? "Data loss will likely occur when trying to save.\n" : "")}" +
                     $"{String.Join("\n", warnings)}");
             }
@@ -435,7 +480,7 @@ public partial class MainViewModel
         catch (Exception e)
         {
             w.EnsureShown();
-            await View!.MessageDialog($"Error opening data file: {e.Message}");
+            await view.MessageDialog($"Error opening data file: {e.Message}");
 
             return false;
         }
@@ -448,9 +493,14 @@ public partial class MainViewModel
 
     public async Task<bool> SaveData(Stream stream)
     {
+        if (Data is null)
+            return false;
+        if (View is not { } view)
+            return false;
+
         IsEnabled = false;
 
-        ILoaderWindow w = View!.LoaderOpen();
+        ILoaderWindow w = view.LoaderOpen();
         w.SetText("Saving data file...");
 
         try
@@ -471,12 +521,12 @@ public partial class MainViewModel
         catch (ProjectException e)
         {
             w.EnsureShown();
-            await View!.MessageDialog($"Recompile error:\n{e.Message}");
+            await view.MessageDialog($"Recompile error:\n{e.Message}");
         }
         catch (Exception e)
         {
             w.EnsureShown();
-            await View!.MessageDialog($"Error saving data file:\n{e.Message}");
+            await view.MessageDialog($"Error saving data file:\n{e.Message}");
         }
         finally
         {
@@ -526,28 +576,43 @@ public partial class MainViewModel
     // Menus
     public async void FileNew()
     {
+        await FileNewTask();
+    }
+
+    public async Task<bool> FileNewTask()
+    {
         if (await AskProjectSave("There are assets marked to be exported in the current project. Save project before closing it?")
             && await AskFileSave("Save data file before creating a new one?"))
         {
             await NewData();
+            return true;
         }
+
+        return false;
     }
 
     public async void FileOpen()
     {
-        if (!await AskProjectSave("There are assets marked to be exported in the current project. Save project before closing it?"))
-            return;
-        if (!await AskFileSave("Save data file before opening a new one?"))
-            return;
+        await FileOpenTask();
+    }
 
-        var files = await View!.OpenFileDialog(new FilePickerOpenOptions()
+    public async Task<bool> FileOpenTask()
+    {
+        if (!await AskProjectSave("There are assets marked to be exported in the current project. Save project before closing it?"))
+            return false;
+        if (!await AskFileSave("Save data file before opening a new one?"))
+            return false;
+        if (View is null)
+            return false;
+
+        var files = await View.OpenFileDialog(new FilePickerOpenOptions()
         {
             Title = "Open data file",
             FileTypeFilter = FilePickerFileTypes.Data,
         });
 
         if (files.Count != 1)
-            return;
+            return false;
 
         CloseData();
 
@@ -556,7 +621,10 @@ public partial class MainViewModel
         if (await LoadData(stream))
         {
             DataPath = files[0].TryGetLocalPath();
+            return true;
         }
+
+        return false;
     }
 
     public async void FileSave()
@@ -568,10 +636,12 @@ public partial class MainViewModel
     {
         if (Data is null)
             return false;
+        if (View is null)
+            return false;
 
         if (Project is not null)
         {
-            var result = await View!.MessageDialog("Save to the project's designated data file for saving?", buttons: MessageWindow.Buttons.YesNoCancel);
+            var result = await View.MessageDialog("Save to the project's designated data file for saving?", buttons: MessageWindow.Buttons.YesNoCancel);
             if (result == MessageWindow.Result.Yes)
             {
                 using FileStream fileStream = File.Open(Project.SaveDataPath, FileMode.Create);
@@ -588,7 +658,7 @@ public partial class MainViewModel
             // If pressed No, continue saving as if there's no project.
         }
 
-        IStorageFile? file = await View!.SaveFileDialog(new FilePickerSaveOptions()
+        IStorageFile? file = await View.SaveFileDialog(new FilePickerSaveOptions()
         {
             Title = "Save data file",
             FileTypeChoices = FilePickerFileTypes.Data,
@@ -611,48 +681,62 @@ public partial class MainViewModel
 
     public async void FileClose()
     {
+        await FileCloseTask();
+    }
+
+    public async Task<bool> FileCloseTask()
+    {
         if (!await AskProjectSave("There are assets marked to be exported in the current project. Save project before closing it?"))
-            return;
+            return false;
         if (!await AskFileSave("Save data file before closing?"))
-            return;
+            return false;
 
         CloseData();
+        return true;
     }
 
     public async void FileRun()
     {
+        await FileRunTask();
+    }
+
+    public async Task<bool> FileRunTask()
+    {
         // NOTE: The project system would make this a lot simpler!
         if (Data is null)
-            return;
+            return false;
+        if (View is null)
+            return false;
 
         string question = $"Save data file before running? {(DataPath is null
             ? " It must be saved before running."
             : $"If it's not saved, the data file at the last location will be used (\"{DataPath}\").")}";
 
         if (!await AskFileSave(question))
-            return;
+            return false;
 
         if (DataPath is null)
-            return;
+            return false;
 
-        var files = await View!.OpenFileDialog(new FilePickerOpenOptions()
+        var files = await View.OpenFileDialog(new FilePickerOpenOptions()
         {
             Title = "Open runner",
             FileTypeFilter = FilePickerFileTypes.All,
         });
 
         if (files.Count != 1)
-            return;
+            return false;
 
         string runnerPath = files[0].TryGetLocalPath() ?? string.Empty;
         if (runnerPath == string.Empty)
-            return;
+            return false;
 
         if (!File.Exists(DataPath))
-            return;
+            return false;
 
         // "launcher" allows game_change data files to still access files above the data path.
         Process.Start(new ProcessStartInfo(runnerPath, $"-game \"{DataPath}\" launcher") { WorkingDirectory = Path.GetDirectoryName(DataPath) });
+        return true;
     }
 
     public async void FileSettings()
@@ -677,26 +761,65 @@ public partial class MainViewModel
 
     public async void ScriptsRunOtherScript()
     {
-        var files = await View!.OpenFileDialog(new FilePickerOpenOptions()
+        await ScriptsRunOtherScriptTask();
+    }
+
+    public async Task<bool> ScriptsRunOtherScriptTask()
+    {
+        if (View is null)
+            return false;
+
+        var files = await View.OpenFileDialog(new FilePickerOpenOptions()
         {
             Title = "Run script",
             FileTypeFilter = FilePickerFileTypes.CS,
         });
 
         if (files.Count != 1)
-            return;
+            return false;
 
-        string text;
+        string? filePath = files[0].TryGetLocalPath();
+        if (filePath is not null && File.Exists(filePath))
+        {
+            return await RunScriptFileAsync(filePath);
+        }
+
         using (Stream stream = await files[0].OpenReadAsync())
         {
             using StreamReader streamReader = new(stream);
-            text = streamReader.ReadToEnd();
+            string text = await streamReader.ReadToEndAsync();
+            await RunScriptTextAsync(text, filePath, files[0].Name);
         }
 
-        string? filePath = files[0].TryGetLocalPath();
+        return true;
+    }
+
+    public async Task<bool> RunScriptFileAsync(string filePath)
+    {
+        if (!File.Exists(filePath))
+        {
+            if (View is null)
+                return false;
+
+            await View.MessageDialog("The script file doesn't exist.");
+            return false;
+        }
+
+        string text = await File.ReadAllTextAsync(filePath);
+        await RunScriptTextAsync(text, filePath, Path.GetFileName(filePath) ?? "Script");
+        return true;
+    }
+
+    private async Task RunScriptTextAsync(string text, string? filePath, string displayName)
+    {
         await Scripting.RunScript(text, filePath);
 
-        CommandTextBoxText = $"{Path.GetFileName(filePath) ?? "Script"} finished!";
+        if (!Scripting.ConsumeFinishedMessageEnabled())
+            return;
+
+        CommandTextBoxText = Scripting.ScriptExecutionSuccess
+            ? $"{displayName} finished!"
+            : Scripting.ScriptErrorMessage;
     }
 
     void ClearProject()
@@ -720,9 +843,12 @@ public partial class MainViewModel
 
     async Task<string?> AskProjectDestinationDataFile()
     {
+        if (View is null)
+            return null;
+
         // Destination data file
         // TODO: Check if same as source and if empty directory
-        IStorageFile? destinationDataFile = await View!.SaveFileDialog(new()
+        IStorageFile? destinationDataFile = await View.SaveFileDialog(new()
         {
             Title = "Select destination data file location",
             FileTypeChoices = FilePickerFileTypes.Data,
@@ -734,33 +860,38 @@ public partial class MainViewModel
 
     public async void ProjectNew()
     {
+        await ProjectNewTask();
+    }
+
+    public async Task<bool> ProjectNewTask()
+    {
         // TODO: Ask for source data file if nothing is opened
         if (Data is null || DataPath is null)
-            return;
+            return false;
+        if (View is null)
+            return false;
 
         if (!await AskProjectSave("There are assets marked to be exported in the current project. Save project before creating a new one?"))
-            return;
-
-        ClearProject();
+            return false;
 
         // Project name
-        string? projectName = await View!.TextBoxDialog("Project name:", $"{Data.GeneralInfo?.DisplayName?.Content ?? "New"} Mod");
+        string? projectName = await View.TextBoxDialog("Project name:", $"{Data.GeneralInfo?.DisplayName?.Content ?? "New"} Mod");
         if (projectName is null)
-            return;
+            return false;
 
         // Project folder
-        IReadOnlyList<IStorageFolder> projectFolderList = await View!.OpenFolderDialog(new() { Title = "Select project folder" });
+        IReadOnlyList<IStorageFolder> projectFolderList = await View.OpenFolderDialog(new() { Title = "Select project folder" });
         string? projectFolderPath = projectFolderList.ElementAtOrDefault(0)?.TryGetLocalPath();
 
         if (projectFolderPath is null)
-            return;
+            return false;
 
         string projectFilePath = Path.Join(projectFolderPath, "project.json");
 
         // Destination data file
         string? destinationDataPath = await AskProjectDestinationDataFile();
         if (destinationDataPath is null)
-            return;
+            return false;
 
         ProjectContext projectContext;
         try
@@ -769,42 +900,51 @@ public partial class MainViewModel
         }
         catch (ProjectException e)
         {
-            await View!.MessageDialog($"Failed to create new project:\n{e.Message}");
-            return;
+            await View.MessageDialog($"Failed to create new project:\n{e.Message}");
+            return false;
         }
         catch (Exception e)
         {
-            await View!.MessageDialog($"Error occurred when creating new project:\n{e}");
-            return;
+            await View.MessageDialog($"Error occurred when creating new project:\n{e}");
+            return false;
         }
 
         DataPath = destinationDataPath;
+        ClearProject();
         SetProject(projectContext);
+        return true;
     }
 
     public async void ProjectOpen()
     {
+        await ProjectOpenTask();
+    }
+
+    public async Task<bool> ProjectOpenTask()
+    {
         // TODO: Ask for source data file if nothing is opened
         if (Data is null || DataPath is null)
-            return;
+            return false;
+        if (View is null)
+            return false;
 
         if (!await AskProjectSave("There are assets marked to be exported in the current project. Save project before opening a new one?"))
-            return;
-
-        ClearProject();
+            return false;
 
         // Project file
-        IReadOnlyList<IStorageFile> projectFileList = await View!.OpenFileDialog(new()
+        IReadOnlyList<IStorageFile> projectFileList = await View.OpenFileDialog(new()
         {
             Title = "Select project.json file",
             FileTypeFilter = FilePickerFileTypes.JSON,
         });
         string? projectFilePath = projectFileList.ElementAtOrDefault(0)?.TryGetLocalPath();
+        if (projectFilePath is null)
+            return false;
 
         // Destination data file
         string? destinationDataPath = await AskProjectDestinationDataFile();
         if (destinationDataPath is null)
-            return;
+            return false;
 
         ProjectContext projectContext;
         try
@@ -814,17 +954,19 @@ public partial class MainViewModel
         }
         catch (ProjectException e)
         {
-            await View!.MessageDialog($"Failed to load project:\n{e.Message}");
-            return;
+            await View.MessageDialog($"Failed to load project:\n{e.Message}");
+            return false;
         }
         catch (Exception e)
         {
-            await View!.MessageDialog($"Error occurred when loading project:\n{e}");
-            return;
+            await View.MessageDialog($"Error occurred when loading project:\n{e}");
+            return false;
         }
 
         DataPath = destinationDataPath;
+        ClearProject();
         SetProject(projectContext);
+        return true;
     }
 
     public async void ProjectSave()
@@ -844,17 +986,25 @@ public partial class MainViewModel
         }
         catch (ProjectException e)
         {
-            await View!.MessageDialog($"Failed to save project:\n{e.Message}");
+            string message = $"Failed to save project:\n{e.Message}";
+            if (View is null)
+                LazyErrorMessages.Add(message);
+            else
+                await View.MessageDialog(message);
         }
         catch (Exception e)
         {
-            await View!.MessageDialog($"Error occurred when saving project:\n{e}");
+            string message = $"Error occurred when saving project:\n{e}";
+            if (View is null)
+                LazyErrorMessages.Add(message);
+            else
+                await View.MessageDialog(message);
         }
 
         return false;
     }
 
-    public async void ProjectViewUnexportedAssets()
+    public void ProjectViewUnexportedAssets()
     {
         if (Project is null || Data is null || DataPath is null)
             return;
@@ -865,21 +1015,44 @@ public partial class MainViewModel
 
     public async void ProjectClose()
     {
+        await ProjectCloseTask();
+    }
+
+    public async Task<bool> ProjectCloseTask()
+    {
         if (!await AskProjectSave("There are assets marked to be exported in the current project. Save project before closing?"))
-            return;
+            return false;
 
         ClearProject();
+        return true;
     }
 
     public async void HelpGitHub()
     {
-        await View!.LaunchUriAsync(new Uri("https://github.com/UnderminersTeam/UndertaleModTool"));
+        await HelpGitHubTask();
+    }
+
+    public async Task<bool> HelpGitHubTask()
+    {
+        if (View is null)
+            return false;
+
+        return await View.LaunchUriAsync(new Uri("https://github.com/UnderminersTeam/UndertaleModTool"));
     }
 
     public async void HelpAbout()
     {
-        await View!.MessageDialog($"UndertaleModTool v{Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "?.?.?.?"} " +
+        await HelpAboutTask();
+    }
+
+    public async Task<bool> HelpAboutTask()
+    {
+        if (View is null)
+            return false;
+
+        await View.MessageDialog($"UndertaleModTool v{Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "?.?.?.?"} " +
             $"by the Underminers team\nLicensed under the GNU General Public License Version 3.", title: "About");
+        return true;
     }
 
     public void SetFilterText(string text)
@@ -889,17 +1062,25 @@ public partial class MainViewModel
 
     public async void DataItemAdd(IList list)
     {
+        await DataItemAddTask(list);
+    }
+
+    public async Task<bool> DataItemAddTask(IList? list)
+    {
         if (Data is null || list is null)
-            return;
+            return false;
 
         UndertaleResource res = UndertaleData.CreateResource(list);
 
         string? name = UndertaleData.GetDefaultResourceName(list);
         if (name is not null)
         {
-            name = await View!.TextBoxDialog("Name of new asset:", name);
+            if (View is null)
+                return false;
+
+            name = await View.TextBoxDialog("Name of new asset:", name);
             if (name is null)
-                return;
+                return false;
 
             static bool IsValidAssetIdentifier(string name)
             {
@@ -919,8 +1100,8 @@ public partial class MainViewModel
 
             if (!IsValidAssetIdentifier(name))
             {
-                await View!.MessageDialog($"Asset name \"{name}\" is not a valid identifier. Only letters, digits and underscore allowed, and it must not start with a digit.");
-                return;
+                await View.MessageDialog($"Asset name \"{name}\" is not a valid identifier. Only letters, digits and underscore allowed, and it must not start with a digit.");
+                return false;
             }
         }
 
@@ -928,7 +1109,10 @@ public partial class MainViewModel
 
         if (res is UndertaleRoom room)
         {
-            if (await View!.MessageDialog("Add the new room to the end of the room order list?", buttons: MessageWindow.Buttons.YesNo) == MessageWindow.Result.Yes)
+            if (View is null)
+                return false;
+
+            if (await View.MessageDialog("Add the new room to the end of the room order list?", buttons: MessageWindow.Buttons.YesNo) == MessageWindow.Result.Yes)
                 Data.GeneralInfo?.RoomOrder.Add(new(room));
         }
 
@@ -951,27 +1135,39 @@ public partial class MainViewModel
         {
             TabOpen(res, inNewTab: true);
         }
+
+        return true;
     }
 
     public async void DataItemRemove(UndertaleResource resource)
     {
+        await DataItemRemoveTask(resource);
+    }
+
+    public async Task<bool> DataItemRemoveTask(UndertaleResource resource)
+    {
         if (Data is null)
-            return;
+            return false;
 
-        if (await View!.MessageDialog($"Delete {resource}?\nNote that the code often references objects by ID, " +
-                    $"so this operation is likely to break stuff because other items will shift up!",
-                    buttons: MessageWindow.Buttons.YesNo) == MessageWindow.Result.Yes)
+        if (View is null)
+            return false;
+
+        if (await View.MessageDialog($"Delete {resource}?\nNote that the code often references objects by ID, " +
+                $"so this operation is likely to break stuff because other items will shift up!",
+                buttons: MessageWindow.Buttons.YesNo) != MessageWindow.Result.Yes)
+            return false;
+
+        // TODO: Maybe do something about all references to this.
+        Data[resource.GetType()].Remove(resource);
+
+        if (Project is not null && resource is IProjectAsset projectAsset)
         {
-            // TODO: Maybe do something about all references to this.
-            Data[resource.GetType()].Remove(resource);
-
-            if (Project is not null && resource is IProjectAsset projectAsset)
-            {
-                Project.UnmarkAssetForExport(projectAsset);
-            }
-
-            // TODO: Close tabs, remove histories
+            Project.UnmarkAssetForExport(projectAsset);
         }
+
+        // TODO: Close tabs, remove histories
+
+        return true;
     }
 
     public TabItemViewModel? TabOpen(object? item, bool inNewTab = false)
@@ -988,11 +1184,11 @@ public partial class MainViewModel
             UndertaleAudioGroup r => new UndertaleAudioGroupViewModel(r),
             UndertaleSound r => new UndertaleSoundViewModel(r, ServiceProvider),
             UndertaleSprite r => new UndertaleSpriteViewModel(r, ServiceProvider),
-            UndertaleBackground r => new UndertaleBackgroundViewModel(r),
+            UndertaleBackground r => new UndertaleBackgroundViewModel(r, ServiceProvider),
             UndertalePath r => new UndertalePathViewModel(r),
             UndertaleScript r => new UndertaleScriptViewModel(r),
             UndertaleShader r => new UndertaleShaderViewModel(r, ServiceProvider),
-            UndertaleFont r => new UndertaleFontViewModel(r),
+            UndertaleFont r => new UndertaleFontViewModel(r, ServiceProvider),
             UndertaleTimeline r => new UndertaleTimelineViewModel(r),
             UndertaleGameObject r => new UndertaleGameObjectViewModel(r, ServiceProvider),
             UndertaleRoom r => new UndertaleRoomViewModel(r, ServiceProvider),
@@ -1006,7 +1202,7 @@ public partial class MainViewModel
             UndertaleEmbeddedTexture r => new UndertaleEmbeddedTextureViewModel(r, ServiceProvider),
             UndertaleEmbeddedAudio r => new UndertaleEmbeddedAudioViewModel(r, ServiceProvider),
             UndertaleTextureGroupInfo r => new UndertaleTextureGroupInfoViewModel(r),
-            UndertaleEmbeddedImage r => new UndertaleEmbeddedImageViewModel(r),
+            UndertaleEmbeddedImage r => new UndertaleEmbeddedImageViewModel(r, ServiceProvider),
             UndertaleAnimationCurve r => new UndertaleAnimationCurveViewModel(r),
             UndertaleParticleSystem r => new UndertaleParticleSystemViewModel(r),
             UndertaleParticleSystemEmitter r => new UndertaleParticleSystemEmitterViewModel(r),

--- a/UndertaleModToolAvalonia/Windows/MainWindow.axaml
+++ b/UndertaleModToolAvalonia/Windows/MainWindow.axaml
@@ -38,7 +38,7 @@
             </NativeMenuItem>
             <NativeMenuItem Header="_Scripts">
                 <NativeMenu>
-                    <NativeMenuItem Header="Run _other script" Command="{Binding ScriptsRunOtherScript}" />
+                    <NativeMenuItem Header="Run _other script..." Command="{Binding ScriptsRunOtherScript}" />
                 </NativeMenu>
             </NativeMenuItem>
             <NativeMenuItem Header="_Project">

--- a/UndertaleModToolAvalonia/Windows/MainWindow.axaml.cs
+++ b/UndertaleModToolAvalonia/Windows/MainWindow.axaml.cs
@@ -1,4 +1,7 @@
-﻿using Avalonia.Controls;
+using System;
+using System.IO;
+using System.Linq;
+using Avalonia.Controls;
 
 namespace UndertaleModToolAvalonia;
 
@@ -7,6 +10,110 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+        BuildScriptsMenu();
+    }
+
+    private void BuildScriptsMenu()
+    {
+        NativeMenu? rootMenu = NativeMenu.GetMenu(this) ?? NativeDock.GetMenu(this);
+        NativeMenuItem? rootScriptItem = rootMenu?.Items.OfType<NativeMenuItem>()
+            .FirstOrDefault(i => i.Header?.ToString() == "_Scripts");
+        if (rootScriptItem is null)
+            return;
+
+        NativeMenu menu = new();
+        PopulateScriptsMenu(menu, Path.Combine(AppContext.BaseDirectory, "Scripts"), isRoot: true);
+        rootScriptItem.Menu = menu;
+    }
+
+    private void PopulateScriptsMenu(NativeMenu menu, string folderDir, bool isRoot)
+    {
+        menu.Items.Clear();
+
+        try
+        {
+            DirectoryInfo directory = new(folderDir);
+
+            if (!directory.Exists)
+            {
+                menu.Items.Add(new NativeMenuItem
+                {
+                    Header = $"(Path {folderDir} does not exist, cannot search for files!)",
+                    IsEnabled = false,
+                });
+            }
+            else
+            {
+                foreach (FileInfo file in directory.EnumerateFiles("*.csx").OrderBy(f => f.Name, StringComparer.OrdinalIgnoreCase))
+                {
+                    string scriptPath = file.FullName;
+                    NativeMenuItem item = new()
+                    {
+                        Header = EscapeMenuHeader(file.Name),
+                    };
+                    item.Click += (_, _) => RunBuiltinScript(scriptPath);
+                    menu.Items.Add(item);
+                }
+
+                foreach (DirectoryInfo subDirectory in directory.EnumerateDirectories().OrderBy(d => d.Name, StringComparer.OrdinalIgnoreCase))
+                {
+                    if (!subDirectory.EnumerateFiles("*.csx").Any())
+                        continue;
+
+                    NativeMenu subMenu = new();
+                    PopulateScriptsMenu(subMenu, subDirectory.FullName, isRoot: false);
+                    menu.Items.Add(new NativeMenuItem
+                    {
+                        Header = EscapeMenuHeader(subDirectory.Name),
+                        Menu = subMenu,
+                    });
+                }
+
+                if (menu.Items.Count == 0)
+                {
+                    menu.Items.Add(new NativeMenuItem
+                    {
+                        Header = "(No scripts found!)",
+                        IsEnabled = false,
+                    });
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            menu.Items.Add(new NativeMenuItem
+            {
+                Header = e.Message,
+                IsEnabled = false,
+            });
+        }
+
+        if (isRoot)
+        {
+            menu.Items.Add(new NativeMenuItemSeparator());
+
+            NativeMenuItem otherScripts = new()
+            {
+                Header = "Run _other script...",
+            };
+            otherScripts.Click += (_, _) =>
+            {
+                if (DataContext is MainViewModel vm)
+                    vm.ScriptsRunOtherScript();
+            };
+            menu.Items.Add(otherScripts);
+        }
+    }
+
+    private static string EscapeMenuHeader(string header)
+    {
+        return header.Replace("_", "__");
+    }
+
+    private async void RunBuiltinScript(string path)
+    {
+        if (DataContext is MainViewModel vm)
+            await vm.RunScriptFileAsync(path);
     }
 
     protected override void OnClosing(WindowClosingEventArgs e)

--- a/UndertaleModToolAvalonia/Windows/MessageWindow.axaml.cs
+++ b/UndertaleModToolAvalonia/Windows/MessageWindow.axaml.cs
@@ -81,7 +81,7 @@ public partial class MessageWindow : Window
 
     public async void Copy()
     {
-        TopLevel topLevel = TopLevel.GetTopLevel(this)!;
-        await topLevel.Clipboard!.SetTextAsync(Message);
+        if (TopLevel.GetTopLevel(this)?.Clipboard is { } clipboard)
+            await clipboard.SetTextAsync(Message);
     }
 }

--- a/UndertaleModToolAvalonia/Windows/SearchInCodeViewModel.cs
+++ b/UndertaleModToolAvalonia/Windows/SearchInCodeViewModel.cs
@@ -58,16 +58,21 @@ public partial class SearchInCodeViewModel
 
     public async void Search()
     {
+        await SearchTask();
+    }
+
+    public async Task<bool> SearchTask()
+    {
         if (MainVM.Data is null)
         {
             StatusBarText = "Error: No data file loaded.";
-            return;
+            return false;
         }
 
         if (MainVM.Data.IsYYC())
         {
             StatusBarText = "Error: Can't search code in YYC game, there's no code to search.";
-            return;
+            return false;
         }
 
         searchText = SearchText.Replace("\r\n", "\n");
@@ -75,7 +80,7 @@ public partial class SearchInCodeViewModel
         if (String.IsNullOrEmpty(searchText))
         {
             StatusBarText = "Error: No text to search.";
-            return;
+            return false;
         }
 
         if (IsRegexSearch)
@@ -87,12 +92,18 @@ public partial class SearchInCodeViewModel
             catch (ArgumentException e)
             {
                 StatusBarText = $"Error: Invalid regex ({e.Message})";
-                return;
+                return false;
             }
         }
 
+        if (View is not { } view)
+        {
+            StatusBarText = "Error: Search window is not attached.";
+            return false;
+        }
+
         // Set up loader window
-        loaderWindow = View!.LoaderOpen();
+        loaderWindow = view.LoaderOpen();
         loaderWindow.SetMaximum(MainVM.Data.Code.Count);
         loaderWindow.SetValue(0);
         loaderWindow.SetMessage("Searching...");
@@ -147,6 +158,7 @@ public partial class SearchInCodeViewModel
 
         IsEnabled = true;
         MainVM.IsEnabled = true;
+        return true;
     }
 
     void SearchInUndertaleCode(UndertaleCode code)

--- a/UndertaleModToolAvalonia/Windows/SettingsWindow.axaml
+++ b/UndertaleModToolAvalonia/Windows/SettingsWindow.axaml
@@ -33,6 +33,9 @@
                           IsChecked="{Binding MainVM.Settings.EnableSyntaxHighlighting}"/>
                 <CheckBox Content="Automatically compile and decompile code on lost focus"
                           IsChecked="{Binding MainVM.Settings.AutomaticallyCompileAndDecompileCodeOnLostFocus}"/>
+                <CheckBox Content="Automatically render image previews"
+                          ToolTip.Tip="If disabled, heavier image previews render only after pressing Render preview."
+                          IsChecked="{Binding MainVM.Settings.AutomaticallyRenderImagePreviews}"/>
 
                 <CheckBox Content="Enable room grid by default"
                           IsChecked="{Binding MainVM.Settings.EnableRoomGridByDefault}"/>

--- a/UndertaleModToolAvalonia/Windows/TextBoxWindow.axaml.cs
+++ b/UndertaleModToolAvalonia/Windows/TextBoxWindow.axaml.cs
@@ -7,6 +7,11 @@ public partial class TextBoxWindow : Window
     public string Message { get; set; } = "Message.";
     public string TitleText { get; set; } = "UndertaleModToolAvalonia";
 
+    public TextBoxWindow()
+    {
+        InitializeComponent();
+    }
+
     public TextBoxWindow(string message, string text = "", string? title = null, bool isMultiline = false, bool isReadOnly = false)
     {
         Message = message;


### PR DESCRIPTION
## Summary

* Improves the Avalonia resource editor with safer preview rendering, richer texture/audio handling, script command support, and broader test coverage.
* Keeps the work stacked on the existing Avalonia port branch so reviewers see only the follow-up changes.

## Changes

* Add guarded image preview rendering, zoom controls, selectable texture-page items, and an auto-render preview setting.
* Add embedded audio playback helpers, audio metadata extraction, and related import/export coverage.
* Add script command/menu support and safer script diagnostics.
* Harden view-model paths, collection notifications, dialog/null guards, and app service disposal.
* Fix package hygiene for Fody/private assets, package README metadata, and generated perf output ignores.
* Add focused Avalonia tests for previews, audio, scripting, settings, converters, and main view behavior.

## Testing

* dotnet build .\UndertaleModTool\UndertaleModTool.csproj -c Debug -p:LangVersion=latest --no-restore --verbosity minimal
* dotnet build .\UndertaleModToolAvalonia\UndertaleModToolAvalonia.csproj -c Debug -p:LangVersion=latest --no-restore --verbosity minimal
* dotnet test .\UndertaleModToolAvalonia.Tests\UndertaleModToolAvalonia.Tests.csproj -c Debug -p:LangVersion=latest --no-restore --verbosity minimal

## Risks

* This is stacked on the draft Avalonia port and should be reviewed in that context, not against master directly.
* No known data migration or save-format changes.

## Notes

* This does not include the separate Underanalyzer invariant-culture parsing fix; that local patch is preserved separately and not part of this PR.